### PR TITLE
Armies of Middle-Earth Update

### DIFF
--- a/Arathorn's Stand.cat
+++ b/Arathorn's Stand.cat
@@ -1,26 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c8b4-cd9a-8a47-131d" name="Arathorn&apos;s Stand" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c8b4-cd9a-8a47-131d" name="Arathorn&apos;s Stand" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="c076-0db7-8691-2939" name="Arathorn&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="c98f-3126-fc5b-7cf7" type="min"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="daef-070c-936d-92fb" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+        <categoryLink id="83c6-a85e-e090-7cdc" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="a237-fc28-2d15-6878" name="Arathorn, Chieftain of the Dúnedain" hidden="false" collective="false" import="true" targetId="5a38-fdeb-da2b-9931" type="selectionEntry"/>
         <entryLink id="0000-a053-2e69-e5e6" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
       </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="234e-e32d-2852-9609" name="Halbarad&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
         <categoryLink id="4017-997d-2fec-1f4b" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="abbb-4bf1-80bf-adea" name="Halbarad" hidden="false" collective="false" import="true" targetId="4431-2a2c-a316-01b8" type="selectionEntry"/>
+        <entryLink id="abbb-4bf1-80bf-adea" name="Halbarad" hidden="false" collective="false" import="true" targetId="4431-2a2c-a316-01b8" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e725-594a-5f18-7bd3" type="min"/>
+          </constraints>
+        </entryLink>
         <entryLink id="f0cd-0ce2-b0ce-744a" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
       </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
     </selectionEntry>
   </selectionEntries>
   <entryLinks>

--- a/Army of Dale.cat
+++ b/Army of Dale.cat
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="73ca-9b98-7ee8-b158" name="Army of Dale" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="63aa-baec-c871-e7d2" name="Brand&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0337-554d-7daa-ff82" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="f617-8cdd-d0ec-8818" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="ea40-8bdb-a917-d07a" name="Brand, King of Dale" hidden="false" collective="false" import="true" targetId="f85b-5d89-7d47-3072" type="selectionEntry"/>
+        <entryLink id="6dbc-e82c-a2f4-a45c" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8cb5-7ea4-3419-7e56" name="Bard II&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="facd-7727-ef4f-a3e3" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="b190-6af7-dfb0-9791" name="Bard II, Prince of Dale" hidden="false" collective="false" import="true" targetId="5d92-1de6-931b-29cd" type="selectionEntry"/>
+        <entryLink id="8377-22a5-7379-a401" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b99e-f88f-1c15-1e02" name="Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="9923-4cd0-846b-eb29" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="1cc6-53b1-6f13-85cb" name="Captain of Dale" hidden="false" collective="false" import="true" targetId="2ec6-5dca-c177-7f37" type="selectionEntry"/>
+        <entryLink id="c50d-3bd9-2962-bc1e" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink id="a6d7-067b-1d20-b427" name="Windlance" hidden="false" collective="false" import="true" targetId="ed0b-ed64-e184-4050" type="selectionEntry"/>
+  </entryLinks>
+  <rules>
+    <rule id="0633-0b56-2050-b4fb" name="Stoic Defence" publicationId="8e2e-f1ed-1aa8-11ca" hidden="false">
+      <description>Once per game, at the start of any Move Phase before the Declare Heroic Actions step, you may declare you are using this ability. If you do, then during the Move Phase friendly models cannot Move during their Activation (but can otherwise act normally). Additionally, until he End Phase of the turn, friendly models gain the Dominant (2) special rule and may re-roll any failed To Wound Rolls when making Strikes.</description>
+    </rule>
+    <rule id="e8dd-54ea-934c-4020" name="Protect the King" publicationId="8e2e-f1ed-1aa8-11ca" hidden="false">
+      <description>Friendly models gain the Sworn Protector (Brand) special rule.</description>
+    </rule>
+    <rule id="cfcb-e7a3-c8b4-4c96" name="Skilled Bowmen" publicationId="8e2e-f1ed-1aa8-11ca" hidden="false">
+      <description>Friendly Dale models improve their Shoot Value to 3+.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/Army of Erebor.cat
+++ b/Army of Erebor.cat
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="6fb2-3253-41fb-106a" name="Army of Erebor" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="64bc-c989-d6a0-8730" name="Dáin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="b193-3d70-bc4d-418e" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="cb5d-fb23-d2da-d39f" name="Dáin Ironfoot, King under the Mountain" hidden="false" collective="false" import="true" targetId="61f5-5178-3fad-5193" type="selectionEntry"/>
+        <entryLink id="0259-d4f9-b3ee-6d77" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e328-0dd7-3608-03d0" name="King&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="6f6b-759a-f52b-5b70" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="a16a-2450-15ba-04b0" name="Erebor" hidden="false" targetId="1e48-8a8f-0bb6-174b" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="5824-2fc5-37b2-7b30" name="Dwarf King" hidden="false" collective="false" import="true" targetId="1b24-f559-d9ce-bf16" type="selectionEntry"/>
+        <entryLink id="f9ba-0476-0124-6695" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e1a4-e0c3-e6cf-0a25" name="Bifur&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="8d5d-f7c9-91a6-8b13" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="e998-bbd7-6a03-7693" name="Bifur the Dwarf, Champion of Erebor" hidden="false" collective="false" import="true" targetId="685b-2377-ddac-7629" type="selectionEntry"/>
+        <entryLink id="8575-faa3-8196-b335" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e52c-a305-6796-fd1e" name="Thorin III&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="fa8d-0641-fc1a-33c2" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="c61c-6b5d-9f2b-e571" name="Thorin III Stonehelm" hidden="false" collective="false" import="true" targetId="2886-6f19-a339-4974" type="selectionEntry"/>
+        <entryLink id="054c-acc7-a794-c02e" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5e01-4b32-a2cc-9826" name="Dwalin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="2d99-39e4-000e-e7ba" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="067e-ebe9-d090-8d93" name="Dwalin the Dwarf, Champion of Erebor" hidden="false" collective="false" import="true" targetId="e3bf-efd2-280d-da3c" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b8de-6494-7d60-eed0" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="bdd2-9123-493a-4299" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="86a7-026a-3a9f-5827" name="Bofur&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="896e-49ba-0cb6-e915" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="7d61-aee1-ab33-42c0" name="Bofur the Dwarf, Champion of Erebor" hidden="false" collective="false" import="true" targetId="d8c7-c8db-bf9d-0274" type="selectionEntry"/>
+        <entryLink id="8442-14d2-4a11-5020" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b936-8fa0-c3cd-3b96" name="Nori&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="53fa-5e24-1efc-1fff" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="559b-5eb6-c953-e500" name="Nori the Dwarf, Champion of Erebor" hidden="false" collective="false" import="true" targetId="9b65-f6c0-37f2-c2ee" type="selectionEntry"/>
+        <entryLink id="5fbb-31a1-c6b2-0cba" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d2ad-5580-f4ec-c5ef" name="Dori&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="9093-9108-88fc-9d27" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="c835-6d63-9da3-4d80" name="Dori the Dwarf, Champion of Erebor" hidden="false" collective="false" import="true" targetId="b83f-be71-3f91-4bf7" type="selectionEntry"/>
+        <entryLink id="5fd5-3a20-2f7c-1f25" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="22d0-924d-2c43-e1d3" name="Gimli&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="cb3a-07d0-53f0-55d5" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="ae46-00a9-ef5e-f1ad" name="Gimli, Son of Glóin" hidden="false" collective="false" import="true" targetId="4072-d158-632b-17b9" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0b16-0ba5-cb83-ef99" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="f64e-dfc1-c327-9e63" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6322-da98-eab6-bc7c" name="Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="e7f0-d49a-4969-882e" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="c902-da9e-2a8c-88c4" name="Iron Hills Captain" hidden="false" collective="false" import="true" targetId="4ada-6ebf-3529-9dad" type="selectionEntry"/>
+        <entryLink id="21fc-6316-3e73-e564" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9897-e94d-36fc-39c7" name="Glóin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="1b0c-f6c3-597a-23e6" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="c8b2-59c6-3e4c-f44d" name="Glóin the Dwarf, Champion of Erebor" hidden="false" collective="false" import="true" targetId="72db-fd1f-cd9c-9395" type="selectionEntry"/>
+        <entryLink id="e2c9-583d-1695-8bc9" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <rules>
+    <rule id="b838-48b8-7e31-c0eb" name="Wall of Steel" publicationId="8e2e-f1ed-1aa8-11ca" page="97" hidden="false">
+      <description>Friendly models that are Supporting gain a bonus of +1 To Wound when making Strikes.</description>
+    </rule>
+    <rule id="d787-8b4c-e8bc-a5ff" name="&quot;For Erebor!&quot;" publicationId="8e2e-f1ed-1aa8-11ca" page="97" hidden="false">
+      <description>Each friendly Hero model may, once per game, declare a Heroic Combat for free.</description>
+    </rule>
+    <rule id="73ed-4719-6fdc-5b28" name="Like Father, Like Son" publicationId="8e2e-f1ed-1aa8-11ca" page="97" hidden="false">
+      <description>Whilst within 3&quot; of each other, Gimli and Glóin may re-roll any failed To Wound Rolls when making Strikes.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/Army of Gothmog.cat
+++ b/Army of Gothmog.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="197d-2b06-50e7-1ae2" name="Army of Gothmog" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="197d-2b06-50e7-1ae2" name="Army of Gothmog" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="0c44-d3ee-6c81-d541" name="Gothmog&apos;s Lieutenant of Sauron" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -64,44 +64,19 @@
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="27f7-df02-4e7f-f2eb" name="Shaman&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="1adf-b0d3-4451-3a83" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="e5b9-df74-f9c0-7566" name="Mordor Orc Shaman" hidden="false" collective="false" import="true" targetId="4211-61ca-c28b-c103" type="selectionEntry"/>
+        <entryLink id="de06-e204-57b1-dee2" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
   </selectionEntries>
   <entryLinks>
-    <entryLink id="b115-2657-8b2e-ef7f" name="Mordor War Catapult" hidden="false" collective="false" import="true" targetId="207d-1974-4adb-f1cc" type="selectionEntry">
-      <modifiers>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6a51-97ca-fd49-d5d5" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0c44-d3ee-6c81-d541" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="333f-d0f7-ece9-d9b6" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0b9d-e1e6-9555-5d0c" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-    </entryLink>
+    <entryLink id="b115-2657-8b2e-ef7f" name="Mordor War Catapult" hidden="false" collective="false" import="true" targetId="207d-1974-4adb-f1cc" type="selectionEntry"/>
+    <entryLink id="f4b7-2a55-4cf0-5d63" name="Mordor Siege Bow" hidden="false" collective="false" import="true" targetId="68ba-fce7-8f51-b34d" type="selectionEntry"/>
   </entryLinks>
   <rules>
     <rule id="90cc-c235-a4df-a7d4" name="The Destruction of Men" publicationId="5d2d-eaa5-64b5-2f28" hidden="false">

--- a/Army of the Great Eye.cat
+++ b/Army of the Great Eye.cat
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="879b-9e9d-0e20-6b96" name="Army of the Great Eye" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="d3d4-c29c-4dc4-77ee" name="Witch-king&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="a5b6-cee4-a4e2-5332" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="79c6-82d4-2c11-5c95" name="The Witch-king of Angmar" hidden="false" collective="false" import="true" targetId="c7f1-a1b7-9395-7624" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72be-9dac-d335-18bd" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="0937-e4f2-544b-c912" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e77d-4707-e4da-88e5" name="Guritz&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="f9f6-b7af-cb74-1257" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="3503-771e-da53-6184" name="Guritz, Master of Reserves" hidden="false" collective="false" import="true" targetId="a628-65dd-fbb2-29f6" type="selectionEntry"/>
+        <entryLink id="78bc-4e6a-527c-db2b" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ab0c-cbdf-e558-25ed" name="Mouth of Sauron&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="44c2-6da9-1931-1248" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="da6c-bd6c-6ec3-4ea1" name="The Mouth of Sauron" hidden="false" collective="false" import="true" targetId="8748-ade8-ad48-ef35" type="selectionEntry"/>
+        <entryLink id="92ad-f60f-c290-8792" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eddb-7631-d60c-07ea" name="Gothmog&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="4071-00d8-da3f-d297" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="bb47-64a7-9ac5-a354" name="Gothmog, Lieutenant of Sauron" hidden="false" collective="false" import="true" targetId="1da5-b8f6-10eb-f3b6" type="selectionEntry"/>
+        <entryLink id="522a-3267-34d8-e604" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c109-a506-3dfc-6194" name="Ringwraith&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="4845-6d4e-ca63-1f26" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="c9f5-a19a-b960-3582" name="Ringwraith" hidden="false" collective="false" import="true" targetId="1f70-d825-bf7c-79e1" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="37d3-b1c5-0369-f8ae" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="3b45-8529-df48-809e" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="fd2b-67e8-4589-3e0c" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bfad-e03d-3b94-e46d" name="Enforcer&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="399a-10e5-77f7-ca24" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="8ecd-d057-d45e-3b64" name="Gothmog&apos;s Enforcer" hidden="false" collective="false" import="true" targetId="8daf-1434-566c-e3b3" type="selectionEntry"/>
+        <entryLink id="1041-2ca3-5e75-328c" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a4b5-55e0-29c9-005b" name="Shagrat&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="aa5e-641c-5077-86f2" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="026c-1791-d247-826f" name="Shagrat, Captain of Cirith Ungol" hidden="false" collective="false" import="true" targetId="3d9e-7f2e-6416-db84" type="selectionEntry"/>
+        <entryLink id="ceef-f752-c568-a024" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="30fc-35a8-fed9-adef" name="Gorbag&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="df7b-733b-f56c-f134" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="5dd1-2986-fb24-514e" name="Gorbag, Orc Captain" hidden="false" collective="false" import="true" targetId="1907-e49c-5267-8ab1" type="selectionEntry"/>
+        <entryLink id="4063-240b-a201-4f95" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9272-d4c7-f4e4-2812" name="Morrannon Orc Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="9098-753a-2805-0dbd" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="7487-28fd-2804-6bc5" name="Morannon Orc Captain" hidden="false" collective="false" import="true" targetId="3e87-be33-d96e-2b50" type="selectionEntry"/>
+        <entryLink id="a46d-babf-6fbf-d764" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d28c-f7a9-5589-db4c" name="Mordor Orc Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="4267-2913-6d01-b2ee" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="c0ae-2822-1d0b-212c" name="Mordor Orc Captain" hidden="false" collective="false" import="true" targetId="8d65-4f5b-0377-030e" type="selectionEntry"/>
+        <entryLink id="d437-13df-6688-c79e" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3095-c777-6983-4189" name="Troll Chieftain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="9945-e57c-2920-0c91" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="be43-2482-a391-4103" name="Mordor Troll Chieftain" hidden="false" collective="false" import="true" targetId="a25e-d316-a85a-235f" type="selectionEntry"/>
+        <entryLink id="6b80-a3a6-a046-d0a4" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e326-70bf-c493-85ab" name="Taskmaster&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="d24d-3ffe-0b34-1fca" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="e014-2c9c-b71f-8bbe" name="Mordor Orc Taskmaster" hidden="false" collective="false" import="true" targetId="e062-6d95-9bca-cfed" type="selectionEntry"/>
+        <entryLink id="f2cd-6546-2aa5-6671" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="75d9-fc41-aac8-67db" name="Uruk-hai Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="e7df-ec71-50bd-57f9" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="f370-6026-223b-38de" name="Mordor Uruk-hai Captain" hidden="false" collective="false" import="true" targetId="08c2-af3a-6bd0-c275" type="selectionEntry"/>
+        <entryLink id="2f85-a6f2-31d4-0965" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3834-32de-8c14-1ba1" name="Marshal&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="269b-b5de-b21f-65b3" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="0785-bbee-2808-6b44" name="Black Númenórean Marshal" hidden="false" collective="false" import="true" targetId="a8c9-27ec-622b-06cf" type="selectionEntry"/>
+        <entryLink id="ff09-37d6-b16a-9d9f" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink id="d229-03cd-1c40-1991" name="Shelob" hidden="false" collective="false" import="true" targetId="4ed1-6df7-90da-1468" type="selectionEntry"/>
+    <entryLink id="4767-5164-f951-03d0" name="Mordor Orc Drummer" hidden="false" collective="false" import="true" targetId="3761-bc72-e9e0-a232" type="selectionEntry"/>
+    <entryLink id="7f6f-dd25-ef1b-72be" name="Mordor Siege Bow" hidden="false" collective="false" import="true" targetId="68ba-fce7-8f51-b34d" type="selectionEntry"/>
+    <entryLink id="50a5-6031-8780-d695" name="Mordor War Catapult" hidden="false" collective="false" import="true" targetId="207d-1974-4adb-f1cc" type="selectionEntry"/>
+  </entryLinks>
+  <rules>
+    <rule id="99f6-e9dd-2aed-f240" name="The Great Eye" publicationId="8e2e-f1ed-1aa8-11ca" page="160" hidden="false">
+      <description>At the beginning of the game, place a 25mm Great Eye Marker on the battlefield in your deployment zone. At the end of each Move Phase, remove the Great Eye Marker and roll a D6. On a 2+ you may place it anywhere within 6&quot; of where it was. On a 1, Sauron has been distracted and your opponent may place it anywhere within 12&quot; of where it was. The Great Eye Marker can never be placed so that it overlaps another model&apos;s base, though models may finish their Move overlapping the Great Eye Marker. Friendly models treat the Great Eye Marker as a banner. Enemy models within 3&quot; of the Great Eye Marker suffer a -1 penalty to any Courage or Intelligence Tests they are required to take.
+
+If your opponent&apos;s Army contains a Ringbearer (with the exception of Sauron), then if during the End Phase of any turn they are wearing the Ring and within 3&quot; of the Great Eye Marker, they must roll a D6. On a 3+, they succumb to Sauron and are immediately removed as a casualty.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/Army of the White Hand.cat
+++ b/Army of the White Hand.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="98e0-c832-f13c-88cf" name="Army of the White Hand" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="98e0-c832-f13c-88cf" name="Army of the White Hand" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="964d-28c7-187c-6334" name="Saruman&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -76,6 +76,24 @@
         <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="bbea-61b3-f416-a1c4" name="Uruk-hai Shaman&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="9613-803e-9319-99cd" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="47d6-b59b-35b9-9101" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+        <entryLink id="9b93-22f5-6c95-5480" name="Uruk-hai Shaman" hidden="false" collective="false" import="true" targetId="93cc-ef43-4615-436b" type="selectionEntry"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="d7a8-d379-d56a-19f3" name="Orc Shaman&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="47cb-a47d-c828-3f36" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="6e14-5895-063a-838f" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+        <entryLink id="74bf-7bb9-9233-fa15" name="Isengard Orc Shaman" hidden="false" collective="false" import="true" targetId="5307-68b6-c4e9-2b96" type="selectionEntry"/>
+      </entryLinks>
     </selectionEntry>
   </selectionEntries>
   <entryLinks>

--- a/Assualt Upon Helm's Deep.cat
+++ b/Assualt Upon Helm's Deep.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="373a-ba54-8792-c30a" name="Assualt Upon Helm&apos;s Deep" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="373a-ba54-8792-c30a" name="Assualt Upon Helm&apos;s Deep" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="884c-6673-5bed-8ec4" name="Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -34,17 +34,18 @@
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="83bf-e7cf-f5e4-dfd1" name="Shaman&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="b959-2a2b-c568-4ce0" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="e160-99c7-a45d-c64e" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+        <entryLink id="a954-caa0-6e90-0ec6" name="Uruk-hai Shaman" hidden="false" collective="false" import="true" targetId="93cc-ef43-4615-436b" type="selectionEntry"/>
+      </entryLinks>
+    </selectionEntry>
   </selectionEntries>
   <entryLinks>
-    <entryLink id="9172-1256-8b53-da19" name="Isengard Assault Ballista" hidden="false" collective="false" import="true" targetId="4807-096b-b538-6fad" type="selectionEntry">
-      <modifiers>
-        <modifier type="increment" field="cecd-985d-067e-5590" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="884c-6673-5bed-8ec4" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-      </modifiers>
-    </entryLink>
+    <entryLink id="9172-1256-8b53-da19" name="Isengard Assault Ballista" hidden="false" collective="false" import="true" targetId="4807-096b-b538-6fad" type="selectionEntry"/>
   </entryLinks>
   <rules>
     <rule id="57f4-92f5-d84a-d325" name="Commander of the Uruk-hai" publicationId="5d2d-eaa5-64b5-2f28" hidden="false">

--- a/Atop the Walls.cat
+++ b/Atop the Walls.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="08e1-50c4-c398-5e15" name="Atop the Walls" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="08e1-50c4-c398-5e15" name="Atop the Walls" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="9bc9-1749-0630-e850" name="Gandalf&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -50,6 +50,24 @@
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="a3da-5167-e41a-0da1" name="Húrin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="1083-b657-7cfc-a1a5" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="401b-b661-62dd-9bbf" name="Húrin the tall, Warden of the Keys" hidden="false" collective="false" import="true" targetId="9517-25f7-8439-f5c4" type="selectionEntry"/>
+        <entryLink id="a6ef-5811-74ff-f8e4" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="aa4d-2c6a-493a-add3" name="Beregond&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="3681-2489-adbf-bd1f" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="cf13-f9d3-618b-3bc0" name="Beregond, Guard of the Citadel" hidden="false" collective="false" import="true" targetId="1357-3b3e-f0ba-3cca" type="selectionEntry"/>
+        <entryLink id="a506-6dbe-df2b-2204" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
   </selectionEntries>
   <entryLinks>
     <entryLink id="880b-1c0f-2b85-4ffd" name="Peregrin Took, Guard of the Citadel" hidden="false" collective="false" import="true" targetId="fd3f-fa33-cf62-b4f0" type="selectionEntry">
@@ -57,25 +75,8 @@
         <categoryLink id="b2af-423f-d9cf-0ced" name="Independant Hero" hidden="false" targetId="13f2-59a9-5a73-a03f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="dc98-92e1-7e5c-23cb" name="Gondor Battlecry Trebuchet" hidden="false" collective="false" import="true" targetId="7276-9a27-52dc-a7fa" type="selectionEntry">
-      <modifiers>
-        <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9bc9-1749-0630-e850" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5f69-b9a6-20e9-da72" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-        <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1d9a-c0c5-654e-7e46" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-    </entryLink>
+    <entryLink id="dc98-92e1-7e5c-23cb" name="Gondor Battlecry Trebuchet" hidden="false" collective="false" import="true" targetId="7276-9a27-52dc-a7fa" type="selectionEntry"/>
+    <entryLink id="7588-1b27-6bf2-47fd" name="Gondor Avenger Bolt Thrower" hidden="false" collective="false" import="true" targetId="6853-fe9e-ea61-3850" type="selectionEntry"/>
   </entryLinks>
   <rules>
     <rule id="2660-b167-e261-838d" name="&quot;Fight to the last Man&quot;" publicationId="5d2d-eaa5-64b5-2f28" hidden="false">

--- a/Barad-dûr.cat
+++ b/Barad-dûr.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3ead-47ab-f886-0aab" name="Barad-dûr" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="8" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3ead-47ab-f886-0aab" name="Barad-dûr" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="edba-2dfa-7255-5055" name="Sauron&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -89,38 +89,29 @@
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="debd-049f-2072-a79e" name="Shaman&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="359b-deb8-4842-76a9" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="3c9c-2d40-8ce5-eba3" name="Mordor Orc Shaman" hidden="false" collective="false" import="true" targetId="4211-61ca-c28b-c103" type="selectionEntry"/>
+        <entryLink id="e838-f613-6949-4475" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="1ee3-e069-418a-e7c0" name="Marshal&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="e227-9bef-1be2-9c88" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="9594-f3f8-d84e-deca" name="Black Númenórean Marshal" hidden="false" collective="false" import="true" targetId="a8c9-27ec-622b-06cf" type="selectionEntry"/>
+        <entryLink id="fd20-2c1b-ba12-42ef" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
   </selectionEntries>
   <entryLinks>
     <entryLink id="1a5d-8f43-347c-fc9c" name="Mordor Orc Drummer" hidden="false" collective="false" import="true" targetId="3761-bc72-e9e0-a232" type="selectionEntry"/>
-    <entryLink id="1ce0-1b55-73de-e037" name="Mordor War Catapult" hidden="false" collective="false" import="true" targetId="207d-1974-4adb-f1cc" type="selectionEntry">
-      <modifiers>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="cfbd-b0c7-3653-e3f4" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="67db-961a-be11-2dad" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="edba-2dfa-7255-5055" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97f7-34f4-adad-84a7" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ea9c-fb59-1c77-6a41" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-      </modifiers>
-    </entryLink>
+    <entryLink id="1ce0-1b55-73de-e037" name="Mordor War Catapult" hidden="false" collective="false" import="true" targetId="207d-1974-4adb-f1cc" type="selectionEntry"/>
+    <entryLink id="2092-7460-7ad5-e97f" name="Mordor Siege Bow" hidden="false" collective="false" import="true" targetId="68ba-fce7-8f51-b34d" type="selectionEntry"/>
   </entryLinks>
   <rules>
     <rule id="9276-3e7e-4700-8048" name="&quot;The power of the Ring could not be undone&quot;" publicationId="5d2d-eaa5-64b5-2f28" hidden="false">

--- a/Battle of Bywater.cat
+++ b/Battle of Bywater.cat
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="906e-ff2a-40c1-877d" name="Battle of Bywater" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="ecec-b8fe-3d79-64ff" name="Merry&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="921c-d4af-a2c4-7a2f" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="9798-25d5-f33e-3a7e" name="Hero of Valour" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="b474-dda3-da82-0e01" name="Brandybuck" hidden="false" targetId="6a9d-f84c-0fc7-420c" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="8c76-9ada-16e8-b0b2" name="Meriadoc Brandybuck, Captain of the Shire" hidden="false" collective="false" import="true" targetId="4a46-0501-0cf5-c7e2" type="selectionEntry"/>
+        <entryLink id="10fe-ed04-64fc-01bf" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6b87-a45c-f4cd-abb9" name="Pippin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="d141-c1fa-b018-01cd" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="540c-05b1-bafe-a19a" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="fa1b-0fe5-010d-c75f" name="Took" hidden="false" targetId="415f-985a-1d6f-5b36" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="6289-4d39-9852-7cf8" name="Peregrin Took, Captain of the Shire" hidden="false" collective="false" import="true" targetId="c6ff-fb7e-18c4-461f" type="selectionEntry"/>
+        <entryLink id="fdc8-07aa-bb2b-9df8" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9004-8b83-24bb-0b32" name="Sam&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="77a1-ea24-c08e-39ec" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="7310-cf07-c53c-ae22" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="9254-9234-1a53-041b" name="Samwise the Brave" hidden="false" collective="false" import="true" targetId="b779-381e-11e1-9cfa" type="selectionEntry"/>
+        <entryLink id="3104-2df8-fa46-724b" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2ecd-c9e0-c5fd-d263" name="Hamfast&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="5365-4feb-1c84-0121" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="da48-acb0-e02f-06a2" name="Hamfast &apos;Gaffer&apos; Gamgee" hidden="false" collective="false" import="true" targetId="30ae-3521-cc19-8d20" type="selectionEntry"/>
+        <entryLink id="c7d9-85b8-f567-9037" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f936-6eff-ba36-79c7" name="Cotton&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="09d3-794e-8cf7-b002" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="0892-d7a7-fbff-2a3c" name="Farmer Tolman Cotton" hidden="false" collective="false" import="true" targetId="c06f-5599-9ba7-1cf9" type="selectionEntry"/>
+        <entryLink id="d91b-6467-b9d8-ec5b" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="96e1-36ae-5a0e-24d3" name="Maggot&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="a168-08fe-f0b9-d7ca" name="Hero of Fortitude" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="3884-7152-442d-60ac" name="Maggot" hidden="false" targetId="37ce-f0ea-f37c-c534" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="65cf-6de7-098e-86f6" name="Farmer Maggot" hidden="false" collective="false" import="true" targetId="fc51-56a8-9f10-2df2" type="selectionEntry"/>
+        <entryLink id="c804-954e-4c4a-8eda" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5898-0c58-5b81-b84a" name="Robin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="3416-a16b-4b2b-b891" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="fc48-d8a8-dadb-cb43" name="Hobbit Shirriff" hidden="false" targetId="38de-7978-da99-08ae" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="25aa-1410-303a-5314" name="Robin Smallburrow, Hobbit Shirriff" hidden="false" collective="false" import="true" targetId="3930-1107-2e17-1edb" type="selectionEntry"/>
+        <entryLink id="7d59-d10e-c85e-18c6" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f976-4c67-0acf-4ca9" name="Holfoot&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="c04e-b539-4416-2426" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="dbba-b910-8f18-2518" name="Hobbit Shirriff" hidden="false" targetId="38de-7978-da99-08ae" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="a779-ddf5-9631-de7c" name="Holfoot Bracegirdle, Shirriff-leader" hidden="false" collective="false" import="true" targetId="16df-9c8e-399f-d159" type="selectionEntry"/>
+        <entryLink id="51cc-c452-1dab-d179" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bf11-5ac5-d26c-be13" name="Will&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="e259-d716-8cb1-978b" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="44d5-0b39-280c-20dd" name="Hobbit Shirriff" hidden="false" targetId="38de-7978-da99-08ae" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="9832-f778-beeb-3b5c" name="Will Witfoot, Mayor of Michel Delving" hidden="false" collective="false" import="true" targetId="1983-176f-b407-4d17" type="selectionEntry"/>
+        <entryLink id="0838-2525-2595-0ff5" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="deb8-86b0-9677-5775" name="Frodo&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="3d21-aeec-aaed-b864" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="6d37-6813-09f0-06d1" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="6796-29c3-ea30-1316" name="Frodo of the Nine Fingers" hidden="false" collective="false" import="true" targetId="92f9-924c-69f3-f062" type="selectionEntry"/>
+        <entryLink id="7f23-8b22-fb28-8934" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f084-c4bb-5bdb-30f5" name="Paladin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="e711-3169-1c5c-6d00" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="6a78-5560-d96b-cc31" name="Took" hidden="false" targetId="415f-985a-1d6f-5b36" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="83d2-be79-694a-dcb4" name="Paladin Took, Thain of the Shire" hidden="false" collective="false" import="true" targetId="2662-776a-2246-0d14" type="selectionEntry"/>
+        <entryLink id="7a66-3fe0-a6ca-38ba" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="09a4-7d1a-68e4-9a48" name="Baldo&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="5952-237f-6bbb-b960" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="28cf-aec5-9c7c-1265" name="Baldo Tulpenny" hidden="false" collective="false" import="true" targetId="36b6-07fa-7152-8b82" type="selectionEntry"/>
+        <entryLink id="9d82-0ee8-62ad-1fab" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3275-e7b5-886e-24c5" name="Fatty&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="e507-109f-8916-7cfe" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="7cd1-d807-2ecf-b133" name="Fredegar &apos;Fatty&apos; Bolger" hidden="false" collective="false" import="true" targetId="1d4e-bda2-959a-0a9f" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="79df-1874-11da-8044" value="1.0"/>
+          </modifiers>
+        </entryLink>
+        <entryLink id="8030-9fde-1e22-cbba" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink id="a041-a05a-bdc9-7651" name="Rosie Cotton" hidden="false" collective="false" import="true" targetId="2608-65f6-64ea-1fd9" type="selectionEntry"/>
+    <entryLink id="d436-19ab-a5e8-d755" name="Lobelia Sackville-Baggins" hidden="false" collective="false" import="true" targetId="c6c3-3058-3e95-e8a7" type="selectionEntry"/>
+    <entryLink id="5b1e-db20-abff-0291" name="Folco Boffin" hidden="false" collective="false" import="true" targetId="241a-bcca-fb7b-04e2" type="selectionEntry"/>
+  </entryLinks>
+  <rules>
+    <rule id="bc36-1b0f-b21a-1132" name="&quot;Fear! Fire! Foes!&quot;" publicationId="8e2e-f1ed-1aa8-11ca" page="72" hidden="false">
+      <description>Friendly Hobbit models gain the Woodland Creature and Mountain Dweller special rules.</description>
+    </rule>
+    <rule id="50af-4969-7644-931e" name="Heroes of the Shire" publicationId="8e2e-f1ed-1aa8-11ca" page="72" hidden="false">
+      <description>Friendly Hobbit Hero models may benefit from the Stand Fast of either Merry or Pippin.</description>
+    </rule>
+    <rule id="f753-44ee-5803-20d8" name="Ambush" publicationId="8e2e-f1ed-1aa8-11ca" page="72" hidden="false">
+      <description>At the start of the game, before either side has deployed, you may choose a single Warband in your Army that is not led by either Frodo, Sam, Merry or Pippin. The chose Warband is ambushing and does not arrive as normal. Instead, at the end of the Move Phase on the third turn (after both sides have moved all their models), the ambushing Warband must choose one of the following;
+
+•Move onto the board from any board edge via the rules for Reinforcements.
+
+•Deploy in, or within 1&quot; of, a wood, building, rocky outcrop or other similar piece of terrain that Hobbis could hide in. A degree of common sense is required when deciding which pieces of terrain Hobbits can hide in - they shouldn&apos;t be leaping out of a river or from behind a single rock! You should always agree with your opponent at the beginning of the game which terrain pieces are eligible for Hobbits to ambush from, Models deployed in this way cannot be placed in base contact with, or within the Control Zones of, enemy models. Models that enter the board in this way do not Activate as part of the Move Phase, and will count as having Moved half their Move Value for the purposes of shooting.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/Battle of Fornost.cat
+++ b/Battle of Fornost.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7e8e-770f-2814-6df9" name="Battle of Fornost" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="7e8e-770f-2814-6df9" name="Battle of Fornost" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="9a08-ef50-ac66-031a" name="Glorfindel&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -59,7 +59,12 @@
         <categoryLink id="03d2-4500-9b28-2db5" name="Dúnedain" hidden="false" targetId="f16a-7b75-3d75-fd19" primary="false"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="35b7-a025-4a21-c037" name="Ranger of the North" hidden="false" collective="false" import="true" targetId="314b-1db4-c42a-fa4f" type="selectionEntry"/>
+        <entryLink id="35b7-a025-4a21-c037" name="Ranger of the North" hidden="false" collective="false" import="true" targetId="314b-1db4-c42a-fa4f" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="c339-3648-4af3-35dc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6d7a-dc76-6cf2-93b1" type="max"/>
+          </constraints>
+        </entryLink>
         <entryLink id="fc73-8bdf-a841-3a04" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>

--- a/Cirith Ungol.cat
+++ b/Cirith Ungol.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="277b-b2f9-d709-4af2" name="Cirith Ungol" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="277b-b2f9-d709-4af2" name="Cirith Ungol" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="5f7d-2d41-c9bd-7090" name="Shagrat&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -86,6 +86,16 @@
         <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="f431-26b5-6cf8-0392" name="Shaman&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="4f18-e641-14f8-a0d2" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+        <categoryLink id="76e2-edfd-c62b-6a58" name="Orc" hidden="false" targetId="5fc7-dee0-a596-75aa" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="1a26-4890-7231-4a92" name="Mordor Orc Shaman" hidden="false" collective="false" import="true" targetId="4211-61ca-c28b-c103" type="selectionEntry"/>
+        <entryLink id="4b99-a803-5c55-17b9" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
     </selectionEntry>
   </selectionEntries>
   <entryLinks>

--- a/Corsair Fleets.cat
+++ b/Corsair Fleets.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="88ca-7707-278c-0323" name="Corsair Fleets" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="88ca-7707-278c-0323" name="Corsair Fleets" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="fc85-c981-c0d9-e9e7" name="Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -32,8 +32,21 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="7568-d4b8-8022-a661" name="General&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="42c6-f5f5-b216-ad4d" value="1.0">
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b506-599f-e86f-8c54" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="30a1-7c51-8827-4d3f" value="0.0">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b506-599f-e86f-8c54" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="42c6-f5f5-b216-ad4d" type="min"/>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="42c6-f5f5-b216-ad4d" type="min"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="30a1-7c51-8827-4d3f" type="max"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="368f-5e90-e900-8fda" name="Hero of Fortitude" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
@@ -42,23 +55,56 @@
         <entryLink id="c870-de8a-549a-fd0b" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
         <entryLink id="b942-0977-212e-b3b2" name="Corsair General" hidden="false" collective="false" import="true" targetId="f21c-0ce8-4dd2-b2d6" type="selectionEntry"/>
       </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3a63-04b6-3c93-27e1" name="Delgamar&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="fa36-cc9d-ecda-e9da" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="d074-c5b4-9836-f7d3" name="Delgamar, Gatemaster of Umbar" hidden="false" collective="false" import="true" targetId="594f-13fb-9882-549b" type="selectionEntry"/>
+        <entryLink id="e591-ee70-5d85-4426" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9722-fb56-5243-5dbd" name="Dalamyr&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="3263-9248-afd1-fc80" value="1.0">
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f21c-0ce8-4dd2-b2d6" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="3263-9248-afd1-fc80" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="9997-6af5-9df8-8620" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="dae2-5a1f-08c6-069f" name="Dalamyr, Fleetmaster of Umbar" hidden="false" collective="false" import="true" targetId="b506-599f-e86f-8c54" type="selectionEntry"/>
+        <entryLink id="0e69-2fac-f796-ea73" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
     </selectionEntry>
   </selectionEntries>
   <entryLinks>
-    <entryLink id="de87-f7ca-3bad-9e14" name="Corsair Ballista" hidden="false" collective="false" import="true" targetId="dbd6-b1e6-c291-b66e" type="selectionEntry">
-      <modifiers>
-        <modifier type="increment" field="387a-7bb7-9592-a168" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fc85-c981-c0d9-e9e7" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-        <modifier type="increment" field="387a-7bb7-9592-a168" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fb9e-d1c8-48ca-5ed8" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-      </modifiers>
-    </entryLink>
+    <entryLink id="de87-f7ca-3bad-9e14" name="Corsair Ballista" hidden="false" collective="false" import="true" targetId="dbd6-b1e6-c291-b66e" type="selectionEntry"/>
   </entryLinks>
   <rules>
     <rule id="2c65-2bfe-f683-600a" name="The Fleetmaster" publicationId="5d2d-eaa5-64b5-2f28" hidden="false">

--- a/Defenders of Erebor.cat
+++ b/Defenders of Erebor.cat
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="21fd-47cc-7b68-bc98" name="Defenders of Erebor" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="4f72-ac60-c0a9-9649" name="Bifur&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="ccc0-e7e5-2edf-03d7" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="d6f8-a0d7-53a6-74c0" name="Unique Erebor" hidden="false" targetId="6e8c-f5b4-ba47-f3d9" primary="false"/>
+        <categoryLink id="cbd3-11a8-7e18-9bdc" name="Erebor" hidden="false" targetId="1e48-8a8f-0bb6-174b" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="3ac9-086a-7de6-98c7" name="Bifur the Dwarf, Champion of Erebor" hidden="false" collective="false" import="true" targetId="685b-2377-ddac-7629" type="selectionEntry"/>
+        <entryLink id="7dc8-7eb6-59e6-bd0f" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f5e8-4825-8519-5000" name="Thorin III&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="1059-6838-25cb-b0d6" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="456f-3b33-a148-0374" name="Unique Erebor" hidden="false" targetId="6e8c-f5b4-ba47-f3d9" primary="false"/>
+        <categoryLink id="4c3d-15b4-5da1-2fb9" name="Erebor" hidden="false" targetId="1e48-8a8f-0bb6-174b" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="2757-ea92-8b06-3e02" name="Thorin III Stonehelm" hidden="false" collective="false" import="true" targetId="2886-6f19-a339-4974" type="selectionEntry"/>
+        <entryLink id="5d23-0835-f111-a5ff" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f21c-3486-6d18-9abb" name="Brand&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="73da-f2e0-4dec-80c6" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+        <categoryLink id="f772-3bcb-7f51-24e1" name="Unique Dale" hidden="false" targetId="8855-88b1-4e3c-f7a0" primary="false"/>
+        <categoryLink id="6761-75f2-9580-739f" name="Dale" hidden="false" targetId="093e-6dc6-cf63-5702" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="f3fe-e78e-f60b-b5d9" name="Brand, King of Dale" hidden="false" collective="false" import="true" targetId="f85b-5d89-7d47-3072" type="selectionEntry"/>
+        <entryLink id="0363-58d3-81d2-312d" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="47bb-f8ee-2fb8-4086" name="Dáin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="b76f-0731-16ae-0ed1" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+        <categoryLink id="656b-b8aa-0887-211f" name="Unique Erebor" hidden="false" targetId="6e8c-f5b4-ba47-f3d9" primary="false"/>
+        <categoryLink id="8a23-6529-6ebd-32f7" name="Erebor" hidden="false" targetId="1e48-8a8f-0bb6-174b" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="2d6e-b5be-cb65-83a2" name="Dáin Ironfoot, King under the Mountain" hidden="false" collective="false" import="true" targetId="61f5-5178-3fad-5193" type="selectionEntry"/>
+        <entryLink id="e65a-75a8-828b-91cd" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e4af-9aae-7cdf-c5c3" name="Dwalin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="cbb5-c88a-db8e-2729" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="6942-5603-7ebc-2593" name="Unique Erebor" hidden="false" targetId="6e8c-f5b4-ba47-f3d9" primary="false"/>
+        <categoryLink id="07b4-db00-1233-1704" name="Erebor" hidden="false" targetId="1e48-8a8f-0bb6-174b" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="1203-9298-e2c1-4b19" name="Dwalin the Dwarf, Champion of Erebor" hidden="false" collective="false" import="true" targetId="e3bf-efd2-280d-da3c" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="3437-dc0c-82c3-2ea2" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="f8c7-0551-5d35-5058" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6151-7724-d79a-0d65" name="Bard II&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="055b-05d2-2877-8aaa" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="f9dc-8bd5-53ac-acc3" name="Unique Dale" hidden="false" targetId="8855-88b1-4e3c-f7a0" primary="false"/>
+        <categoryLink id="936b-ccfa-cfd8-45b7" name="Dale" hidden="false" targetId="093e-6dc6-cf63-5702" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="6623-ecb5-f4bb-5d42" name="Bard II, Prince of Dale" hidden="false" collective="false" import="true" targetId="5d92-1de6-931b-29cd" type="selectionEntry"/>
+        <entryLink id="686e-0a1e-4d79-ee15" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fc94-d7a7-c71e-f377" name="Bofur&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="7fca-e8f7-2f0f-89df" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="c81b-ec52-0396-792f" name="Unique Erebor" hidden="false" targetId="6e8c-f5b4-ba47-f3d9" primary="false"/>
+        <categoryLink id="cbb5-c315-c205-5496" name="Erebor" hidden="false" targetId="1e48-8a8f-0bb6-174b" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="6110-379a-3994-adc6" name="Bofur the Dwarf, Champion of Erebor" hidden="false" collective="false" import="true" targetId="d8c7-c8db-bf9d-0274" type="selectionEntry"/>
+        <entryLink id="81e1-bc6b-3e84-3b74" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b451-32e5-fdef-dc02" name="Glóin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="ca0a-f2d1-4cf2-36e5" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="8512-6a32-44c7-eb22" name="Unique Erebor" hidden="false" targetId="6e8c-f5b4-ba47-f3d9" primary="false"/>
+        <categoryLink id="3a2f-9cd9-8389-69d3" name="Erebor" hidden="false" targetId="1e48-8a8f-0bb6-174b" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="d8f6-edd1-6f4b-37e6" name="Glóin the Dwarf, Champion of Erebor" hidden="false" collective="false" import="true" targetId="72db-fd1f-cd9c-9395" type="selectionEntry"/>
+        <entryLink id="8def-5cf2-7de0-2c63" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cd96-446d-3a05-32ed" name="Nori&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="a985-6226-58b5-9b45" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="a6e7-5c26-06e7-bd01" name="Unique Erebor" hidden="false" targetId="6e8c-f5b4-ba47-f3d9" primary="false"/>
+        <categoryLink id="0f70-883e-2882-23ed" name="Erebor" hidden="false" targetId="1e48-8a8f-0bb6-174b" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="039c-fc1b-8849-cab1" name="Nori the Dwarf, Champion of Erebor" hidden="false" collective="false" import="true" targetId="9b65-f6c0-37f2-c2ee" type="selectionEntry"/>
+        <entryLink id="fd31-993f-ed14-ade5" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5c56-1f96-559d-e67b" name="Dale Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="707e-6785-1453-aa69" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="d99b-bdf9-1aa6-d7d2" name="Dale" hidden="false" targetId="093e-6dc6-cf63-5702" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="31c3-bd47-f2f5-b091" name="Captain of Dale" hidden="false" collective="false" import="true" targetId="2ec6-5dca-c177-7f37" type="selectionEntry"/>
+        <entryLink id="8d94-57b5-994c-c226" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="37e3-b5d5-9e3f-5e14" name="Dori&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="44cb-7523-3d00-cd9e" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="0cf3-baf2-7921-e208" name="Unique Erebor" hidden="false" targetId="6e8c-f5b4-ba47-f3d9" primary="false"/>
+        <categoryLink id="e65e-0125-6adf-8819" name="Erebor" hidden="false" targetId="1e48-8a8f-0bb6-174b" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="129b-4747-d168-a080" name="Dori the Dwarf, Champion of Erebor" hidden="false" collective="false" import="true" targetId="b83f-be71-3f91-4bf7" type="selectionEntry"/>
+        <entryLink id="2b12-9957-23bb-8f3c" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3376-872e-9645-8c25" name="Iron HIlls Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="7104-44ce-33ca-6b49" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="cb60-795c-43d8-9500" name="Erebor" hidden="false" targetId="1e48-8a8f-0bb6-174b" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="f1c6-0c99-bdf9-1722" name="Iron Hills Captain" hidden="false" collective="false" import="true" targetId="4ada-6ebf-3529-9dad" type="selectionEntry"/>
+        <entryLink id="e3ee-4dc7-53e2-1fc5" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <rules>
+    <rule id="340f-a1d8-e6fa-d819" name="The Heirs to the Kingdom" publicationId="8e2e-f1ed-1aa8-11ca" page="98" hidden="false">
+      <description>At the beginning of the Fight Phase, at the start of the Declare Heroic Actions step, if either Thorin or Bard would be considered Trapped then the other may declare a Heroic Combat for free. If this Heroic Combat is successful, the Thorin or Bard must use the following Move to join the other&apos;s Combat. If this is not possilble, then Thorin or Bard must Move as close as possible to the other. A model cannot use this special rule if they are in the same Combat as the other.</description>
+    </rule>
+    <rule id="305a-e1d3-e908-4b75" name="Royal Bloodlines" publicationId="8e2e-f1ed-1aa8-11ca" page="98" hidden="false">
+      <description>Friendly models treat each of Dáin, Thorin III, Brand and Bard as a banner.</description>
+    </rule>
+    <rule id="d6a8-d2c8-2602-4369" name="Long-standing Alliance" publicationId="8e2e-f1ed-1aa8-11ca" page="98" hidden="false">
+      <description>Friendly Dale models within 1&quot; of a friendly Erebor model may re-roll To Wound Rolls of a natural 1 when making Strikes. Friendly Erebor models within 1&quot; of a friendly Dale model may re-roll To Wound Rolls of a natural 1 when making Strikes.</description>
+    </rule>
+    <rule id="aee1-c52f-ddab-71f6" name="A Bond Forged in War" publicationId="8e2e-f1ed-1aa8-11ca" page="98" hidden="false">
+      <description>At the beginning of the Fight Phase, at the start of the Declare Heroic Actions step, if either Dáin or Brand would be considered Trapped then the other may declare a Heroic Combat for free. If this Heroic Combat is successful, the Dáin or Brand must use the following Move to join the other&apos;s Combat. If this is not possilble, then Dáin or Brand must Move as close as possible to the other. A model cannot use this special rule if they are in the same Combat as the other.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/Defenders of the Pelennor.cat
+++ b/Defenders of the Pelennor.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="b665-e970-845c-4926" name="Defenders of the Pelennor" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="b665-e970-845c-4926" name="Defenders of the Pelennor" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="f865-7ba5-7282-45aa" name="Théoden&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -117,7 +117,11 @@
         <categoryLink id="0cf4-9614-04f7-28cb" name="Rohan" hidden="false" targetId="0d50-809e-7dc4-939a" primary="false"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="7369-e9e5-4ff8-9c14" name="Éowyn, Shieldmaiden of Rohan" hidden="false" collective="false" import="true" targetId="b9a5-82a3-89d1-0913" type="selectionEntry"/>
+        <entryLink id="7369-e9e5-4ff8-9c14" name="Éowyn, Shieldmaiden of Rohan" hidden="false" collective="false" import="true" targetId="b9a5-82a3-89d1-0913" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="c321-021a-c7d8-4a35" type="min"/>
+          </constraints>
+        </entryLink>
         <entryLink id="0a51-f07e-0fd6-b804" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
@@ -225,6 +229,233 @@
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="e567-78e2-bafa-f3e3" name="Imrahil&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="f8ac-f2e2-c0a5-4f8c" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+        <categoryLink id="de14-864a-6ae7-3c17" name="Gondor" hidden="false" targetId="b4ea-7715-d55b-7e78" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="ace1-ad2e-1cb6-23cb" name="Prince Imrahil of Dol Amroth" hidden="false" collective="false" import="true" targetId="7e3a-526d-1010-e0d9" type="selectionEntry"/>
+        <entryLink id="68d8-0247-5016-9661" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3b96-ef2e-d409-11fe" name="Forlong&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="e6a5-4aab-f75f-33fd" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="dbf4-0ee9-dd65-ef3e" name="Gondor" hidden="false" targetId="b4ea-7715-d55b-7e78" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="af0b-e309-2735-cc81" name="Forlong the Fat" hidden="false" collective="false" import="true" targetId="a7c2-f660-d0d7-491a" type="selectionEntry"/>
+        <entryLink id="8587-5272-ac53-ed60" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="55fe-8684-6f0c-fe7d" name="Déorwine&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="f0ff-1c67-fe4c-7a3f" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="2977-bdca-c626-dc31" name="Rohan" hidden="false" targetId="0d50-809e-7dc4-939a" primary="false"/>
+        <categoryLink id="6165-493d-f5d0-b465" name="Rohan Royal Guard" hidden="false" targetId="3414-6388-2318-1371" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="3a95-87b3-4dcc-665b" name="Déorwine, Chief of the King&apos;s Knights" hidden="false" collective="false" import="true" targetId="fe95-b1c9-fb94-0b25" type="selectionEntry"/>
+        <entryLink id="c25b-5a14-098b-2936" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="df54-da9c-de71-b9bb" name="Elfhelm&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="f519-3800-f30f-ba13" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="a364-e767-6d5b-0e24" name="Rohan" hidden="false" targetId="0d50-809e-7dc4-939a" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="18d8-1444-a3ae-1333" name="Elfhelm, Captain of Rohan" hidden="false" collective="false" import="true" targetId="a2b3-b7a5-8d8e-5a83" type="selectionEntry"/>
+        <entryLink id="a00f-668c-cc99-befb" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="84e7-c97a-fac2-ad5e" name="Twins Warbands" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="e42f-f74b-c007-4657" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="fa31-e3ae-6700-f7a1" name="Twins" hidden="false" targetId="557f-c13b-ea47-c1a7" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3083-5c1d-faa5-f66a" name="Elladan&apos;s Warband" hidden="false" collective="false" import="true" type="unit">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="8920-dbbc-d961-7146" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="7feb-9973-4a8a-c921" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="fb00-c11b-23e3-abf4" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+            <entryLink id="b4ae-9953-6ad5-bd78" name="Elladan" hidden="false" collective="false" import="true" targetId="6008-3674-8dd1-fcd6" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+            <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+            <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+            <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="af7c-992b-b74a-4c7f" name="Elrohir&apos;s Warband" hidden="false" collective="false" import="true" type="unit">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ddb5-0613-fc8e-0a00" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="2fcc-11e5-90a2-e471" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="75e6-3799-7cea-9412" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+            <entryLink id="2e63-3d8c-c474-e8b9" name="Elrohir" hidden="false" collective="false" import="true" targetId="f6fc-d3c3-3b11-10ed" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+            <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+            <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+            <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4d66-fdf0-f058-6646" name="Beregond&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="10f9-358d-3e6b-0cc5" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="45a6-7500-b78d-3c4b" name="Gondor" hidden="false" targetId="b4ea-7715-d55b-7e78" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="964b-3a24-025f-7f60" name="Beregond, Guard of the Citadel" hidden="false" collective="false" import="true" targetId="1357-3b3e-f0ba-3cca" type="selectionEntry"/>
+        <entryLink id="30a6-cb9f-0a2f-5ba3" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8cc0-e443-940e-bc41" name="Ingold&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="2934-d5d8-aa8c-ef16" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="fae3-3b6d-04c3-543d" name="Gondor" hidden="false" targetId="b4ea-7715-d55b-7e78" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="f6c1-9de4-430d-da9a" name="Ingold, Warden of the Rammas Echor" hidden="false" collective="false" import="true" targetId="fda1-fc6b-219b-51a2" type="selectionEntry"/>
+        <entryLink id="8389-3a4d-343e-0594" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6c31-8a93-6d32-83cd" name="Húrin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="e962-4371-5e12-1105" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="ab2e-2fb2-daa0-0349" name="Gondor" hidden="false" targetId="b4ea-7715-d55b-7e78" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="04f2-d436-cbfc-9415" name="Húrin the tall, Warden of the Keys" hidden="false" collective="false" import="true" targetId="9517-25f7-8439-f5c4" type="selectionEntry"/>
+        <entryLink id="a601-56b9-1213-5c1f" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0ac3-0421-8b37-22d8" name="Halbarad&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="6c53-a571-cb17-90d4" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="0c9f-e6a8-05d7-1464" name="Halbarad" hidden="false" targetId="e5aa-0e82-ba0c-c720" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="b94b-c16c-7890-655b" name="Halbarad" hidden="false" collective="false" import="true" targetId="4431-2a2c-a316-01b8" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="a971-c19f-1e64-4195" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="05bb-25a5-8977-f9d0" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e33f-5788-a240-67ea" name="Angbor&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="517a-9eeb-bef4-2d3b" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="6ed7-8dbb-793a-f2a4" name="Gondor" hidden="false" targetId="b4ea-7715-d55b-7e78" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="04bb-e220-da4a-da9c" name="Angbor the Fearless" hidden="false" collective="false" import="true" targetId="5c2e-552b-8384-6e49" type="selectionEntry"/>
+        <entryLink id="0455-5215-413a-9f63" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="37d3-9229-7236-60f9" name="Captain of Dol Amroth&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="995e-1044-5b4e-9540" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="4aa9-94b4-5dfb-2a42" name="Gondor" hidden="false" targetId="b4ea-7715-d55b-7e78" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="898f-2da2-98bd-39f2" name="Captain of Dol Amroth" hidden="false" collective="false" import="true" targetId="ae1a-757f-80f3-b7de" type="selectionEntry"/>
+        <entryLink id="cce4-62b7-37a9-5236" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7232-e035-157f-2f79" name="Duinhir&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="ab3d-3739-7dc1-27f8" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="ce2a-fb16-e84f-0c36" name="Gondor" hidden="false" targetId="b4ea-7715-d55b-7e78" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="29fb-2311-4c2f-0616" name="Duinhir, Lord of the Blackroot Vale" hidden="false" collective="false" import="true" targetId="ed04-c308-74ce-9787" type="selectionEntry"/>
+        <entryLink id="0db8-b222-e2b2-8c8f" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </selectionEntries>
   <entryLinks>
     <entryLink id="9e41-fea1-4785-aa82" name="Peregrin Took, Guard of the Citadel" hidden="false" collective="false" import="true" targetId="fd3f-fa33-cf62-b4f0" type="selectionEntry">
@@ -232,80 +463,8 @@
         <categoryLink id="2768-a7e2-f606-fa67" name="Independent Hero" hidden="false" targetId="13f2-59a9-5a73-a03f" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="295a-c7af-d6c4-adc8" name="Gondor Battlecry Trebuchet" hidden="false" collective="false" import="true" targetId="7276-9a27-52dc-a7fa" type="selectionEntry">
-      <modifiers>
-        <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1a55-91d3-e2a5-797e" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f783-d512-7548-0ba1" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f865-7ba5-7282-45aa" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0b55-6922-5203-7f83" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="82a0-9881-300c-7cc6" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-        <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ad67-daf9-0741-ab0c" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b5f7-a64a-91e7-b1ad" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="03d1-3440-86af-9163" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9408-f952-b0cc-9780" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4520-5377-d034-7f2a" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f865-7ba5-7282-45aa" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d1cb-705e-f22c-1b54" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1091-5fe8-b7b2-6978" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-        <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b043-b771-13b5-cdcd" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-      </modifiers>
-    </entryLink>
+    <entryLink id="295a-c7af-d6c4-adc8" name="Gondor Battlecry Trebuchet" hidden="false" collective="false" import="true" targetId="7276-9a27-52dc-a7fa" type="selectionEntry"/>
+    <entryLink id="7b3d-3ebd-bf23-8c90" name="Gondor Avenger Bolt Thrower" hidden="false" collective="false" import="true" targetId="6853-fe9e-ea61-3850" type="selectionEntry"/>
   </entryLinks>
   <rules>
     <rule id="8da0-66b8-6d5f-1055" name="Defend the White City" publicationId="5d2d-eaa5-64b5-2f28" hidden="false">

--- a/Depths of Moria.cat
+++ b/Depths of Moria.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d30b-4eff-973a-a098" name="Depths of Moria" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="d30b-4eff-973a-a098" name="Depths of Moria" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="59eb-1f13-743c-c974" name="Balrog&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -9,6 +9,12 @@
         <entryLink id="225f-f678-45b5-03e0" name="The Balrog" hidden="false" collective="false" import="true" targetId="dd7d-493e-24ce-7861" type="selectionEntry"/>
         <entryLink id="77fe-7d21-3c3a-d600" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
       </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="7244-494a-de70-efd7" name="Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -17,6 +23,21 @@
       <entryLinks>
         <entryLink id="50cd-374f-b604-d79b" name="Moria Goblin Captain" hidden="false" collective="false" import="true" targetId="be58-9759-de81-8d67" type="selectionEntry"/>
         <entryLink id="b202-7367-1169-9b6a" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8b9c-b631-b010-0305" name="Shaman&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="39bd-a67f-466e-030d" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="ea8e-f43c-6329-03b2" name="Moria Goblin Shaman" hidden="false" collective="false" import="true" targetId="08fb-c2ef-0811-bfba" type="selectionEntry"/>
+        <entryLink id="7943-846d-f3c0-a7c4" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
       </entryLinks>
     </selectionEntry>
   </selectionEntries>

--- a/Dragons of the North.cat
+++ b/Dragons of the North.cat
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="e572-5a8c-c833-a02e" name="Dragons of the North" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <entryLinks>
+    <entryLink id="e1a2-2ce5-a8b3-e36a" name="Dragon" hidden="false" collective="false" import="true" targetId="4203-5f4e-fdfd-53a7" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1f94-9c9d-d7f7-4b35" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="6a78-9140-e77e-c8d1" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="e017-e8c1-5eb7-7d79" name="Cave Drake" hidden="false" collective="false" import="true" targetId="3863-7e13-dffc-e8d0" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="1cb7-4d3d-211b-cb96" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+  </entryLinks>
+  <rules>
+    <rule id="edaa-8841-0e14-cde2" name="The Dragons&apos; Hoard" publicationId="8e2e-f1ed-1aa8-11ca" page="160" hidden="false">
+      <description>Each time a friendly model slays an enemy model in Combat they may roll a D6. On a natural 6, they have located some gold upon the body of the fallen and claimed it for themselves - keep a note of how much gold each model claims in this way. Friendly models gain the following benefits depending on how much gold they have collected. These benefits are cumulative:
+
+•1 gold - The model may re-roll a single To Wound Roll when making Strikes.
+•2-3 gold - The model may re-roll a single D6 during a Duel Roll.
+•4-5 gold - The model gains the Fearless special rule.
+•6+ gold - At the end of the game, their controlling player will gain an additional 1 Victory Point. This can never take this Army&apos;s total number of Victory Points above 20.</description>
+    </rule>
+    <rule id="7e73-98dd-1585-d8c3" name="Beast of Legend" publicationId="8e2e-f1ed-1aa8-11ca" hidden="false">
+      <description>The Dragon that is your General may select up to three options rather than the usual two.</description>
+    </rule>
+    <rule id="c1b1-e66b-749d-7fbf" name="Supreme Jealousy" publicationId="8e2e-f1ed-1aa8-11ca" hidden="false">
+      <description>Each Dragon in your Army must have a differeny combination of option. Dragons that have no options do not count for he purpose of this special rule.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/Erebor & Dale.cat
+++ b/Erebor & Dale.cat
@@ -1,29 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="3483-71cc-8cd3-40c6" name="Erebor &amp; Dale" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="3483-71cc-8cd3-40c6" name="Erebor &amp; Dale" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="9f58-aad5-71fa-49ab" name="Thrór&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="9d20-f644-e438-6f9e" value="1.0">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9f58-aad5-71fa-49ab" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1ec9-6d28-b1f0-be19" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d03c-2d45-c9dd-6e4c" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7e3-6784-2605-3832" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="87ee-c89e-7475-a5ea" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="9d20-f644-e438-6f9e" type="min"/>
-      </constraints>
       <categoryLinks>
         <categoryLink id="e705-8649-81d8-a353" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
         <categoryLink id="d72a-f25c-67d3-e7d1" name="Thrór" hidden="false" targetId="961e-6497-c1b3-e107" primary="false"/>
         <categoryLink id="ca65-6ca7-04e0-a741" name="Dwarf" hidden="false" targetId="9d10-67eb-ac11-f2e4" primary="false"/>
+        <categoryLink id="5e6c-359c-ad18-b660" name="Unique Erebor" hidden="false" targetId="6e8c-f5b4-ba47-f3d9" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="c5ec-7e99-262c-6197" name="Thrór, King Under the Mountain" hidden="false" collective="false" import="true" targetId="06e7-896d-d1f5-3d05" type="selectionEntry"/>
@@ -37,27 +20,10 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="87ee-c89e-7475-a5ea" name="Thorin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="4b83-cf68-8344-ce1d" value="1.0">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9f58-aad5-71fa-49ab" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1ec9-6d28-b1f0-be19" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d03c-2d45-c9dd-6e4c" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7e3-6784-2605-3832" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="87ee-c89e-7475-a5ea" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="4b83-cf68-8344-ce1d" type="min"/>
-      </constraints>
       <categoryLinks>
         <categoryLink id="21a8-ba47-c636-9153" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
         <categoryLink id="8569-589c-084c-4043" name="Dwarf" hidden="false" targetId="9d10-67eb-ac11-f2e4" primary="false"/>
+        <categoryLink id="c6f8-8362-8a57-40d7" name="Unique Erebor" hidden="false" targetId="6e8c-f5b4-ba47-f3d9" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="05d1-5569-708c-b62a" name="Young Thorin Oakenshield" hidden="false" collective="false" import="true" targetId="c7ff-da69-5a9c-939f" type="selectionEntry"/>
@@ -71,27 +37,10 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="d03c-2d45-c9dd-6e4c" name="Balin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="ec79-d0f7-9937-d691" value="1.0">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9f58-aad5-71fa-49ab" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1ec9-6d28-b1f0-be19" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d03c-2d45-c9dd-6e4c" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7e3-6784-2605-3832" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="87ee-c89e-7475-a5ea" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ec79-d0f7-9937-d691" type="min"/>
-      </constraints>
       <categoryLinks>
         <categoryLink id="e24c-8a37-9287-fd20" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
         <categoryLink id="7f5b-1ee8-b69c-d534" name="Dwarf" hidden="false" targetId="9d10-67eb-ac11-f2e4" primary="false"/>
+        <categoryLink id="d5ee-9c71-12c7-a252" name="Unique Erebor" hidden="false" targetId="6e8c-f5b4-ba47-f3d9" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="5d8b-efb0-1cf9-fbfc" name="Young Balin the Dwarf" hidden="false" collective="false" import="true" targetId="095d-4fa5-d3c4-09e5" type="selectionEntry"/>
@@ -153,27 +102,10 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="d7e3-6784-2605-3832" name="Dwalin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="dc45-fa71-ec7c-7761" value="1.0">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9f58-aad5-71fa-49ab" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1ec9-6d28-b1f0-be19" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d03c-2d45-c9dd-6e4c" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7e3-6784-2605-3832" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="87ee-c89e-7475-a5ea" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="dc45-fa71-ec7c-7761" type="min"/>
-      </constraints>
       <categoryLinks>
         <categoryLink id="7ea7-81f3-de8e-e034" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
         <categoryLink id="e9bb-0102-48b4-3275" name="Dwarf" hidden="false" targetId="9d10-67eb-ac11-f2e4" primary="false"/>
+        <categoryLink id="7c5f-3ae2-b65e-bde3" name="Unique Erebor" hidden="false" targetId="6e8c-f5b4-ba47-f3d9" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="2009-d154-4731-44fc" name="Young Dwalin the Dwarf" hidden="false" collective="false" import="true" targetId="e6d6-acf7-de38-e9b9" type="selectionEntry"/>
@@ -206,27 +138,10 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="1ec9-6d28-b1f0-be19" name="Thráin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="6b62-5ec7-33b9-7967" value="1.0">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9f58-aad5-71fa-49ab" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1ec9-6d28-b1f0-be19" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d03c-2d45-c9dd-6e4c" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7e3-6784-2605-3832" type="equalTo"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="87ee-c89e-7475-a5ea" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6b62-5ec7-33b9-7967" type="min"/>
-      </constraints>
       <categoryLinks>
         <categoryLink id="4d11-2292-2a5e-83a1" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
         <categoryLink id="61c8-4adb-441a-cd86" name="Dwarf" hidden="false" targetId="9d10-67eb-ac11-f2e4" primary="false"/>
+        <categoryLink id="8d89-769a-0001-104e" name="Unique Erebor" hidden="false" targetId="6e8c-f5b4-ba47-f3d9" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="0d06-26c7-ed92-dbaf" name="Thráin, Son of Thrór" hidden="false" collective="false" import="true" targetId="b625-1878-17dc-a70e" type="selectionEntry"/>

--- a/Fords of Isen.cat
+++ b/Fords of Isen.cat
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="e017-2b6b-f344-6bc7" name="Fords of Isen" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="a534-56a0-c13a-0e62" name="Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="63d1-290e-9ffb-d99f" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="8f5d-641d-1fc6-0c8d" name="Captain of Rohan" hidden="false" collective="false" import="true" targetId="4299-42b8-c5ec-79e4" type="selectionEntry"/>
+        <entryLink id="df7e-0267-ce14-4515" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="1616-12f2-038d-f37e" name="Elfhelm&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="da85-e75c-0b43-e539" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="0773-e2d5-54e8-e1ba" name="Elfhelm, Captain of Rohan" hidden="false" collective="false" import="true" targetId="a2b3-b7a5-8d8e-5a83" type="selectionEntry"/>
+        <entryLink id="5d6e-d5ab-dd33-fc45" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="8aed-ad7a-da46-83aa" name="Théodred&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="890b-fab9-7658-9ee5" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="6950-54b7-d58f-6bdc" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="eaf1-1099-df8e-2dc1" name="Rohan Royal Guard" hidden="false" targetId="3414-6388-2318-1371" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="d8f5-f6e8-32a0-40fa" name="Théodred, Prince of Rohan" hidden="false" collective="false" import="true" targetId="366b-80dc-b64a-3fe6" type="selectionEntry"/>
+        <entryLink id="9072-06e5-c859-b399" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+  </selectionEntries>
+  <rules>
+    <rule id="8026-9f40-86c3-9d46" name="Protect the Prince" publicationId="8e2e-f1ed-1aa8-11ca" page="81" hidden="false">
+      <description>Friendly models gain the Sworn Protector (Théodred) special rule.</description>
+    </rule>
+    <rule id="5ec8-5a9e-6fa4-3db7" name="Resolute Rohirrim" publicationId="8e2e-f1ed-1aa8-11ca" page="81" hidden="false">
+      <description>If your Army is Broken, friendly models gain the Dominant (2) special rule.</description>
+    </rule>
+    <rule id="c966-402d-1c25-928b" name="The Courage of Elfhelm" publicationId="8e2e-f1ed-1aa8-11ca" page="81" hidden="false">
+      <description>If Théodredis Engaged in Combat within 6&quot; of Elfhelm, then enemy models may not make Strikes against Théodred if there is another model they could make Strikes against instead.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/Garrison of Dale.cat
+++ b/Garrison of Dale.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="1a10-56ea-e57f-3084" name="Garrison of Dale" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="1a10-56ea-e57f-3084" name="Garrison of Dale" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="32ac-20dd-a1d0-ff81" name="Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -36,15 +36,7 @@
     </selectionEntry>
   </selectionEntries>
   <entryLinks>
-    <entryLink id="e373-3014-e2c6-a933" name="Windlance" hidden="false" collective="false" import="true" targetId="ed0b-ed64-e184-4050" type="selectionEntry">
-      <modifiers>
-        <modifier type="increment" field="28da-e67b-b4f3-0a62" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="32ac-20dd-a1d0-ff81" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-      </modifiers>
-    </entryLink>
+    <entryLink id="e373-3014-e2c6-a933" name="Windlance" hidden="false" collective="false" import="true" targetId="ed0b-ed64-e184-4050" type="selectionEntry"/>
   </entryLinks>
   <rules>
     <rule id="9fd9-182a-4311-1336" name="&quot;Girion, lord of the city, rallied his bowmen to fire upon the beast&quot;" publicationId="a40a-1ac4-b5c2-a481" page="95" hidden="false">

--- a/Grand Army of the South.cat
+++ b/Grand Army of the South.cat
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="0e30-df42-5824-7a47" name="Grand Army of the South" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="5b22-e9be-7a83-cf30" name="War Leader&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="c35a-4fdb-3ba1-aeb3" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+        <categoryLink id="9f7d-6efd-ea85-c8cd" name="Harad" hidden="false" targetId="f38f-e6bf-d67d-3a2c" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="4157-1c93-abd9-e682" name="Mûmak War Leader" hidden="false" collective="false" import="true" targetId="f0c8-cf8a-d98f-9e88" type="selectionEntry"/>
+        <entryLink id="fb93-c81a-80c8-6092" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="72be-7584-d33b-7c52" name="Amdûr&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="b927-9d73-9c80-1ad9" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="e8ff-b81e-4204-02a7" name="Easterling" hidden="false" targetId="35ba-7f33-c093-2662" primary="false"/>
+        <categoryLink id="43e9-3e04-b3bd-5f76" name="Black Dragon" hidden="false" targetId="4a72-9b0e-9a1c-3881" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="38f7-cb33-e1c6-5e73" name="Amdûr, Lord of Blades" hidden="false" collective="false" import="true" targetId="a3ab-6fbd-b823-7bfd" type="selectionEntry"/>
+        <entryLink id="5576-1ce9-a87f-b69c" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cbb0-c1e4-5bb7-38e7" name="Râza&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="206f-d1a2-47a5-0ec5" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="c164-efbc-de39-12bd" name="Harad" hidden="false" targetId="f38f-e6bf-d67d-3a2c" primary="false"/>
+        <categoryLink id="db92-55ad-5096-8b4c" name="Serpent Guard" hidden="false" targetId="1a7e-5429-722d-642c" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="57f9-0406-9ae7-a1e3" name="Râza, Fang of the Serpent" hidden="false" collective="false" import="true" targetId="e969-153e-5e22-c64a" type="selectionEntry"/>
+        <entryLink id="bcf4-b71a-d1b7-5fd0" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b3fe-a968-3d93-3937" name="Dragon Knight&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="5135-8424-4af5-4806" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+        <categoryLink id="1681-e4f3-be7f-1630" name="Black Dragon" hidden="false" targetId="4a72-9b0e-9a1c-3881" primary="false"/>
+        <categoryLink id="02cf-9759-9e49-1ca6" name="Easterling" hidden="false" targetId="35ba-7f33-c093-2662" primary="false"/>
+        <categoryLink id="2c64-61ab-91c0-4f4f" name="Dragon Knight" hidden="false" targetId="efee-4410-dfee-f34d" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="aea6-1209-da1f-5ccb" name="Easterling Dragon Knight" hidden="false" collective="false" import="true" targetId="25c2-59ac-2b5d-e41d" type="selectionEntry"/>
+        <entryLink id="6d5a-44fe-1bd5-c1fb" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b19b-61b0-dbfd-4926" name="Dalamyr&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="52fa-bde9-6369-a14c" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+        <categoryLink id="7e42-4e2b-437d-2150" name="Corsair" hidden="false" targetId="5ce0-6bc5-a0fd-8348" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="04be-f572-6a19-d0fc" name="Dalamyr, Fleetmaster of Umbar" hidden="false" collective="false" import="true" targetId="b506-599f-e86f-8c54" type="selectionEntry"/>
+        <entryLink id="103c-1474-de2e-cf61" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="709f-9bb3-e982-68cc" name="Suladân&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="dc27-98b9-2e17-3ee1" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+        <categoryLink id="8a07-fb1d-0034-fc0d" name="Harad" hidden="false" targetId="f38f-e6bf-d67d-3a2c" primary="false"/>
+        <categoryLink id="f888-d9ab-66a4-bc71" name="Serpent Guard" hidden="false" targetId="1a7e-5429-722d-642c" primary="false"/>
+        <categoryLink id="7a16-2328-c8e5-fca9" name="Serpent Rider" hidden="false" targetId="c310-8640-6445-1bbc" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="7ebd-5102-ee22-af28" name="Suladân, the Serpent Lord" hidden="false" collective="false" import="true" targetId="b9f0-a4f7-6d7e-d895" type="selectionEntry"/>
+        <entryLink id="3e86-4973-af2f-af64" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4268-0551-996c-bf05" name="Delgamar&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="4aaf-a1fb-ab6d-e046" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="99a6-c8f1-30a5-806f" name="Corsair" hidden="false" targetId="5ce0-6bc5-a0fd-8348" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="e48e-f7a1-29be-0686" name="Delgamar, Gatemaster of Umbar" hidden="false" collective="false" import="true" targetId="594f-13fb-9882-549b" type="selectionEntry"/>
+        <entryLink id="4a89-8262-7313-5a64" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d3ac-decb-f546-c755" name="Mûmak&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="dbe0-f5b3-51e0-5bdb" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="d642-52c1-7103-c9ac" name="Harad" hidden="false" targetId="f38f-e6bf-d67d-3a2c" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="905e-c255-383b-0927" name="War Mûmak of Harad" hidden="false" collective="false" import="true" targetId="5ed9-a83f-ad98-678f" type="selectionEntry"/>
+        <entryLink id="603a-546c-836e-cfdf" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ee05-c6b3-1b0e-f987" name="Taskmaster&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="c15f-5964-dc5a-b093" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="82e8-72b3-d2b6-6f64" name="Harad" hidden="false" targetId="f38f-e6bf-d67d-3a2c" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="3389-5343-273c-0577" name="Haradrim Taskmaster" hidden="false" collective="false" import="true" targetId="e2a8-1554-a481-dd59" type="selectionEntry"/>
+        <entryLink id="fc0e-b82f-442b-2905" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="769f-f4bd-31b7-6124" name="Kataphrakt Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="522d-ef9f-06cf-8b71" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="0e7e-29b1-9397-d979" name="Easterling" hidden="false" targetId="35ba-7f33-c093-2662" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="7f7b-5aa3-2015-aaee" name="Easterling Kataphrakt Captain" hidden="false" collective="false" import="true" targetId="0156-7c08-a86f-275b" type="selectionEntry"/>
+        <entryLink id="1b4e-a98a-0cdc-1fd7" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a9a4-43c1-523f-7437" name="Priest&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="3d29-8a82-f210-a220" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="dee4-d729-169f-0861" name="Easterling" hidden="false" targetId="35ba-7f33-c093-2662" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="53af-4e61-66ad-fae5" name="Easterling War Priest" hidden="false" collective="false" import="true" targetId="0895-8943-5206-d301" type="selectionEntry"/>
+        <entryLink id="06ef-a8f6-ce35-4e5d" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="33cd-b061-0d61-1fa3" name="Hâsharin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="f27f-a663-26bc-eec8" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="8d2e-67ce-a1a1-706a" name="Harad" hidden="false" targetId="f38f-e6bf-d67d-3a2c" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="f359-9254-2438-4e48" name="Hâsharin" hidden="false" collective="false" import="true" targetId="a573-9adf-207b-b3a4" type="selectionEntry"/>
+        <entryLink id="5ecc-5074-29c8-5c8d" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c7df-2853-653d-9eee" name="Corsair Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="af0d-c350-0576-4993" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="1d05-8a1a-cfa1-28b1" name="Corsair" hidden="false" targetId="5ce0-6bc5-a0fd-8348" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="5c49-aa39-8612-efa8" name="Corsair Captain" hidden="false" collective="false" import="true" targetId="61a7-12dd-9618-bde4" type="selectionEntry"/>
+        <entryLink id="5a86-4166-e891-f6b9" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4125-fc59-c5a6-17db" name="Bo&apos;sun&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="60fe-587d-fc0c-af48" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="0540-bd38-0051-5d95" name="Corsair" hidden="false" targetId="5ce0-6bc5-a0fd-8348" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="473e-30f1-8bbd-9fa4" name="Corsair Bo&apos;sun" hidden="false" collective="false" import="true" targetId="d376-bd96-e155-91c0" type="selectionEntry"/>
+        <entryLink id="482d-76d9-6ee8-7f93" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9beb-09f4-ec12-96dc" name="Easterling Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="3ebd-c6ae-8070-a1f9" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="31a4-c3c8-7a08-d392" name="Easterling" hidden="false" targetId="35ba-7f33-c093-2662" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="3ad1-49e4-9508-409e" name="Easterling Captain" hidden="false" collective="false" import="true" targetId="dbb7-1ded-4dfc-def8" type="selectionEntry"/>
+        <entryLink id="41ab-0147-4ed4-8ac8" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4d08-f1ca-f036-4957" name="Chieftain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="291b-ee8a-12a8-50c1" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="31c1-4fed-c694-73a1" name="Harad" hidden="false" targetId="f38f-e6bf-d67d-3a2c" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="59d5-81a5-0154-26d0" name="Haradrim Chieftain" hidden="false" collective="false" import="true" targetId="7b92-0e7b-2637-a09d" type="selectionEntry"/>
+        <entryLink id="51f1-70c6-59c6-6d27" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <rules>
+    <rule id="96f4-33a8-ef83-6ebb" name="Pride of the Southlands" publicationId="8e2e-f1ed-1aa8-11ca" hidden="false">
+      <description>Friendly models gain a bonus of +1 to any Courage Tests they are required to take.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/Harad.cat
+++ b/Harad.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="96e3-133a-a151-e3e8" name="Harad" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="96e3-133a-a151-e3e8" name="Harad" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="1256-78e9-3775-6fd8" name="War Leader&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -9,6 +9,12 @@
         <entryLink id="ebe4-38e0-0241-5fad" name="Mûmak War Leader" hidden="false" collective="false" import="true" targetId="f0c8-cf8a-d98f-9e88" type="selectionEntry"/>
         <entryLink id="7095-7275-bd59-0bc0" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
       </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="1b37-b0bf-8bb4-c26d" name="War Mûmak&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -18,6 +24,12 @@
         <entryLink id="9f17-71d8-61a4-f175" name="War Mûmak of Harad" hidden="false" collective="false" import="true" targetId="5ed9-a83f-ad98-678f" type="selectionEntry"/>
         <entryLink id="7b02-c958-60ba-e745" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
       </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="c735-082b-94bd-98de" name="Chieftain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -26,6 +38,21 @@
       <entryLinks>
         <entryLink id="635f-06d5-8450-4cc2" name="Haradrim Chieftain" hidden="false" collective="false" import="true" targetId="7b92-0e7b-2637-a09d" type="selectionEntry"/>
         <entryLink id="af2a-9f13-0459-7c13" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="24a4-75c5-0dca-6d77" name="Taskmaster&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="fbc9-73c9-9a00-0013" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="d504-7f9f-2bfc-a8af" name="Haradrim Taskmaster" hidden="false" collective="false" import="true" targetId="e2a8-1554-a481-dd59" type="selectionEntry"/>
+        <entryLink id="3e75-2c50-14bc-e83b" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
       </entryLinks>
     </selectionEntry>
   </selectionEntries>

--- a/Host of the Dragon Emperor.cat
+++ b/Host of the Dragon Emperor.cat
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="ac20-2983-11dd-0565" name="Host of the Dragon Emperor" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="8a79-276c-8728-ed51" name="Emperor&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="f882-5210-c902-6867" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="cf73-4465-7bdb-73c8" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="b83d-a17f-dc7f-3156" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+        <categoryLink id="fc15-8504-35be-8657" name="Black Dragon" hidden="false" targetId="4a72-9b0e-9a1c-3881" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="17a6-7043-6b8c-4b3c" name="The Dragon Emperor of Rhûn" hidden="false" collective="false" import="true" targetId="6a2a-863b-bdb1-3262" type="selectionEntry"/>
+        <entryLink id="7e98-a945-cf2b-6a83" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1fed-4ccd-6ab2-4cf4" name="Rutabi&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0e7a-c328-7262-b514" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="a8c4-226e-87ff-df79" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="519d-ec7a-4941-f838" name="Rutabi, General of the Dragon Legion" hidden="false" collective="false" import="true" targetId="a06a-cf41-2b2a-ec7a" type="selectionEntry"/>
+        <entryLink id="6e76-d5cb-f078-ca07" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4def-44e8-0246-38d6" name="Brórgír&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="8358-ee29-b20c-a9fe" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="3168-f506-addf-3038" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="c0f0-d9a0-7994-bd41" name="Brórgír" hidden="false" collective="false" import="true" targetId="146b-71fd-de79-6ac2" type="selectionEntry"/>
+        <entryLink id="07b2-2ba0-af26-a8ac" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="44fe-4c3f-b424-1958" name="Infantry Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="705a-5420-6ad4-ba0a" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="be77-34d7-21cc-62dd" name="Easterling Captain" hidden="false" collective="false" import="true" targetId="dbb7-1ded-4dfc-def8" type="selectionEntry"/>
+        <entryLink id="ba5b-657a-9700-6e07" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d419-79e0-1cee-56d6" name="Kataphrakt Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="43d2-775c-65a3-3109" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="false"/>
+        <categoryLink id="fd70-dd59-646f-da01" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="6d10-1e33-c8c9-27fa" name="Easterling Kataphrakt Captain" hidden="false" collective="false" import="true" targetId="0156-7c08-a86f-275b" type="selectionEntry"/>
+        <entryLink id="e73a-d4ae-636c-f57c" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d34b-5da1-a638-2fe2" name="Priest&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="3511-bc99-85c8-e89d" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="cc60-985b-7745-0541" name="Easterling War Priest" hidden="false" collective="false" import="true" targetId="0895-8943-5206-d301" type="selectionEntry"/>
+        <entryLink id="a8dd-51cc-ce1f-5644" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7d8e-1aa7-3d09-8b87" name="Knight&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="5602-3d75-d792-ce1e" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+        <categoryLink id="4a04-2216-f0db-dfdf" name="Black Dragon" hidden="false" targetId="4a72-9b0e-9a1c-3881" primary="false"/>
+        <categoryLink id="9edb-b3c4-cfc2-fea8" name="Dragon Knight" hidden="false" targetId="efee-4410-dfee-f34d" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="3b8d-553b-9826-81b7" name="Easterling Dragon Knight" hidden="false" collective="false" import="true" targetId="25c2-59ac-2b5d-e41d" type="selectionEntry"/>
+        <entryLink id="1be0-b09f-71de-505d" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <rules>
+    <rule id="6a5b-8db1-bbdf-69de" name="Heroes of the Easterlings" publicationId="8e2e-f1ed-1aa8-11ca" hidden="false">
+      <description>Friendly Easterling Hero models may re-roll a single D6 in a Duel Roll.</description>
+    </rule>
+    <rule id="4a53-6b2a-c904-e57a" name="Easterling Phalanxes" publicationId="8e2e-f1ed-1aa8-11ca" hidden="false">
+      <description>Friendly models Supported by two other friendly models gain a bonus of +1 To Wound when making Strikes.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/Kingdom of Khazad-dûm.cat
+++ b/Kingdom of Khazad-dûm.cat
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="a09f-62e2-2467-e539" name="Kingdom of Khazad-dûm" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="c525-206b-5a77-571b" name="Durin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="bb7e-8f35-d8af-f350" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+        <categoryLink id="e4fd-8124-fc92-2098" name="Khazâd Guard" hidden="false" targetId="e9d8-23eb-ff25-20d0" primary="false"/>
+        <categoryLink id="0909-76a6-d6cb-4686" name="Durin" hidden="false" targetId="1035-91c0-7c43-fce0" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="0325-06d6-d46b-2dfb" name="Durin, King of Khazad-Dûm" hidden="false" collective="false" import="true" targetId="dbd9-7d70-1dd1-e3bb" type="selectionEntry"/>
+        <entryLink id="2c81-1b8a-e53e-bc34" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="40d7-b951-2b97-4f25" name="Mardin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0e14-6815-dd2e-02d3" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="9b16-ac5e-00c6-bb63" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="3f9c-7afc-837d-e620" name="Mardin, the King&apos;s Ward" hidden="false" collective="false" import="true" targetId="cdf5-4ac9-b950-7d7a" type="selectionEntry"/>
+        <entryLink id="e686-6f45-5747-d168" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1f0d-e42e-4731-5f9a" name="Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="c305-512e-8109-69e4" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="f1b8-6041-176c-168b" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="fb4a-b0fd-a0dc-8f41" name="Dwarf Captain" hidden="false" collective="false" import="true" targetId="59a3-c86b-49e0-f2e4" type="selectionEntry"/>
+        <entryLink id="5e90-2c01-5ad4-5e03" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="13e7-f8e7-e5ab-7eef" name="King&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="add" field="category" value="e9d8-23eb-ff25-20d0">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="68b7-fc9b-6d13-64c3" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="1a41-5b0e-5c6a-37b2" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="6e7d-d5fa-d690-8ae1" name="Khazad-dûm" hidden="false" targetId="774f-acf4-4c50-c082" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="8b34-0bf9-fdf7-fe02" name="Dwarf King" hidden="false" collective="false" import="true" targetId="1b24-f559-d9ce-bf16" type="selectionEntry"/>
+        <entryLink id="58d0-3831-ed80-6450" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink id="65ef-56a1-ffd8-6336" name="Dwarven Ballista" hidden="false" collective="false" import="true" targetId="ac6c-c78e-ee26-fa6b" type="selectionEntry"/>
+  </entryLinks>
+  <rules>
+    <rule id="6d58-a0db-0102-4be3" name="&quot;The wealth of Moria lay not in gold or jewels, but in Mithril&quot;" publicationId="8e2e-f1ed-1aa8-11ca" page="95" hidden="false">
+      <description>Friendly models may re-roll To Wound Rolls of a natural 1 when making Strikes.</description>
+    </rule>
+    <rule id="f7b7-9347-9ce6-8c00" name="Steadfast Warriors" publicationId="8e2e-f1ed-1aa8-11ca" page="95" hidden="false">
+      <description>Friendly Dwarf Captains, Dwarf Warriors and Dwarf Rangers gain the Dominant (2) special rule.</description>
+    </rule>
+    <rule id="2865-ccfa-9db4-25f7" name="The Stubbornness of Dwarves" publicationId="8e2e-f1ed-1aa8-11ca" page="95" hidden="false">
+      <description>During a Duel Roll, before any re-roll have been used, if the opposition player has rolled more dice (including Supporting models), then a single friendly Khazad-dûm model may re-roll a single D6 as part of the Duel Roll.</description>
+    </rule>
+    <rule id="62e2-b947-58ac-d581" name="Dwarven Mirrors" publicationId="8e2e-f1ed-1aa8-11ca" page="95" hidden="false">
+      <description>At the start of the game, after both sides have deployed, you may deploy two 40mm Dwarven Mirror Markers anywhere on the battlefield that is not within the opposition deployment zone. The area within 6&quot; of a Dwarven Mirror Marker with a shooting attack suffers a -1 penalty to the To Hit Roll.
+
+Additionally, Orc models, Goblin models, or models with the Cave Dweller special rule, suffer a -1 penalty to any Courage Tests they are required to take whilst within 6&quot; of a Dwarven Mirror Marker. If, during the End Phase of a turn, an enemy model is in base contact with a Dwarven Mirror Marker, that model hasn&apos;t done anything during that turn except Move (i.e., has not made a shooting attack, cast a Magical Power, been Engaged in Combat), and that model was not affected by a Magical Power that turn, then it can remove the Dwarven Mirror Marker from play. Models cannot overlap a Dwarven Mirror Marker for any reason, though a War Beast or Chariot that Moves into base contact with one (via Trample or Chariot Charge respectively) will immediately remove it from play and may carry on as normal.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/Kingdom of Rohan.cat
+++ b/Kingdom of Rohan.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="89f3-76d4-bb65-29fd" name="Kingdom of Rohan" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="89f3-76d4-bb65-29fd" name="Kingdom of Rohan" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="e997-bf75-abff-a801" name="Théoden&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -54,7 +54,11 @@
         <categoryLink id="853b-bbc9-8870-ddc8" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="c264-ebbd-0f53-943b" name="Éowyn, Shieldmaiden of Rohan" hidden="false" collective="false" import="true" targetId="b9a5-82a3-89d1-0913" type="selectionEntry"/>
+        <entryLink id="c264-ebbd-0f53-943b" name="Éowyn, Shieldmaiden of Rohan" hidden="false" collective="false" import="true" targetId="b9a5-82a3-89d1-0913" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="a716-a018-0cff-c0e8" type="min"/>
+          </constraints>
+        </entryLink>
         <entryLink id="0871-5097-3330-a895" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
@@ -103,6 +107,37 @@
       <entryLinks>
         <entryLink id="8634-a9af-e3d8-0ba5" name="Éomer, Marshal of the Riddermark" hidden="false" collective="false" import="true" targetId="16a7-271a-69c0-6b85" type="selectionEntry"/>
         <entryLink id="e2a6-6b0c-ccd1-0d91" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7513-7dfd-c524-def1" name="Déorwine&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="db8b-fb67-6e49-b1d6" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="cad0-2907-0e2d-8b1a" name="Rohan Royal Guard" hidden="false" targetId="3414-6388-2318-1371" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="2520-6d1b-24f1-e6b1" name="Déorwine, Chief of the King&apos;s Knights" hidden="false" collective="false" import="true" targetId="fe95-b1c9-fb94-0b25" type="selectionEntry"/>
+        <entryLink id="40d4-98dc-3579-a1fc" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9e0a-8b7f-3de9-8001" name="Elfhelm&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="7547-b3bb-b9cf-b686" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="8fa3-706a-3ac2-39ed" name="Elfhelm, Captain of Rohan" hidden="false" collective="false" import="true" targetId="a2b3-b7a5-8d8e-5a83" type="selectionEntry"/>
+        <entryLink id="2136-d044-7132-3b82" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>

--- a/Legions of Mordor.cat
+++ b/Legions of Mordor.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="801f-52ae-3745-1dba" name="Legions of Mordor" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="8" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="801f-52ae-3745-1dba" name="Legions of Mordor" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="8a52-f4ff-d92b-1556" name="Witch-king&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -170,62 +170,166 @@
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="179d-8927-3c2c-2148" name="Marshal&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="75f9-33f2-f175-1732" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="8e80-5f0e-9e80-26cb" name="Mordor" hidden="false" targetId="5edd-85a7-0250-3a10" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="776f-1db1-8c30-8eb1" name="Black Númenórean Marshal" hidden="false" collective="false" import="true" targetId="a8c9-27ec-622b-06cf" type="selectionEntry"/>
+        <entryLink id="54da-cb26-7f5c-059f" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="772a-a764-adb5-163a" name="Amdûr&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="b9b0-b3fd-0546-60b9" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="8b24-cd59-6461-357d" name="Easterling" hidden="false" targetId="35ba-7f33-c093-2662" primary="false"/>
+        <categoryLink id="0fe0-ffde-c470-6c59" name="Black Dragon" hidden="false" targetId="4a72-9b0e-9a1c-3881" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="5e19-452b-9592-b120" name="Amdûr, Lord of Blades" hidden="false" collective="false" import="true" targetId="a3ab-6fbd-b823-7bfd" type="selectionEntry"/>
+        <entryLink id="1079-56e5-79eb-1528" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fa97-f94b-312e-d95a" name="Dragon Knight&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="1284-7138-08a6-b8b2" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+        <categoryLink id="7d65-ea46-4393-b171" name="Easterling" hidden="false" targetId="35ba-7f33-c093-2662" primary="false"/>
+        <categoryLink id="b158-3d89-37d7-1fa5" name="Dragon Knight" hidden="false" targetId="efee-4410-dfee-f34d" primary="false"/>
+        <categoryLink id="6dc5-cacd-3363-6050" name="Black Dragon" hidden="false" targetId="4a72-9b0e-9a1c-3881" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="181c-909a-2fc6-f430" name="Easterling Dragon Knight" hidden="false" collective="false" import="true" targetId="25c2-59ac-2b5d-e41d" type="selectionEntry"/>
+        <entryLink id="5f82-2ac0-a0f1-be04" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1dec-1d32-a9c6-a09e" name="Shaman&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="df67-ee55-af0f-a304" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+        <categoryLink id="f7ed-cdda-fef8-3fb4" name="Mordor" hidden="false" targetId="5edd-85a7-0250-3a10" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="5233-cc16-9a95-d5df" name="Mordor Orc Shaman" hidden="false" collective="false" import="true" targetId="4211-61ca-c28b-c103" type="selectionEntry"/>
+        <entryLink id="00d9-f818-0afe-e8cc" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1a6e-1933-1f81-4e46" name="Suladân&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="efb8-72e4-1d5b-27fa" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="2333-ee46-f462-df49" name="New CategoryLink" hidden="false" targetId="f38f-e6bf-d67d-3a2c" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="b381-b20e-60fc-3964" name="Suladân, the Serpent Lord" hidden="false" collective="false" import="true" targetId="b9f0-a4f7-6d7e-d895" type="selectionEntry"/>
+        <entryLink id="7d93-dbb6-a152-2127" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7020-caf4-0b28-ab56" name="Priest&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="0cf6-e8d2-d615-a95c" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="0677-2996-9392-4f1e" name="Easterling" hidden="false" targetId="35ba-7f33-c093-2662" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="adc9-5e25-7657-f6b4" name="Easterling War Priest" hidden="false" collective="false" import="true" targetId="0895-8943-5206-d301" type="selectionEntry"/>
+        <entryLink id="c524-d648-b3af-8d00" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c6e1-609a-78d7-36ee" name="Hâsharin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="29f7-b0e8-a492-24d4" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="26a0-178d-8815-0ea8" name="Harad" hidden="false" targetId="f38f-e6bf-d67d-3a2c" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="22f3-2c34-66af-bf4b" name="Hâsharin" hidden="false" collective="false" import="true" targetId="a573-9adf-207b-b3a4" type="selectionEntry"/>
+        <entryLink id="ca4a-ecc6-965e-0cbc" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e72b-2e84-f6fb-5379" name="Taskmaster&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="4d90-e455-c25b-f9b8" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="d223-4769-55b6-43b9" name="Harad" hidden="false" targetId="f38f-e6bf-d67d-3a2c" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="2017-f7f3-80fc-d83f" name="Haradrim Taskmaster" hidden="false" collective="false" import="true" targetId="e2a8-1554-a481-dd59" type="selectionEntry"/>
+        <entryLink id="54ee-82a3-d433-71bc" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5c48-3589-5a86-883b" name="Kataphrakt Captain" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="7f4e-ef63-e50b-f192" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="5e0d-26b1-86b5-b153" name="Easterling" hidden="false" targetId="35ba-7f33-c093-2662" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="8c03-daa0-543f-fc1a" name="Easterling Kataphrakt Captain" hidden="false" collective="false" import="true" targetId="0156-7c08-a86f-275b" type="selectionEntry"/>
+        <entryLink id="35b3-4cc6-4d82-2be0" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bbc2-b014-7c4d-46a0" name="Râza&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="f37a-f3ed-3a40-2bb9" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="2708-f9df-b0c7-32b6" name="Harad" hidden="false" targetId="f38f-e6bf-d67d-3a2c" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="cfed-006b-0730-73c2" name="Râza, Fang of the Serpent" hidden="false" collective="false" import="true" targetId="e969-153e-5e22-c64a" type="selectionEntry"/>
+      </entryLinks>
+    </selectionEntry>
   </selectionEntries>
   <entryLinks>
-    <entryLink id="2766-7ea3-4ff6-91b8" name="Mordor War Catapult" hidden="false" collective="false" import="true" targetId="207d-1974-4adb-f1cc" type="selectionEntry">
-      <modifiers>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2b60-8797-f043-6ac8" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5241-60ee-79dd-c192" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b277-76ff-e704-c43b" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c855-86f4-8aca-b6f1" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9ea2-25cd-17ea-9859" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8a52-f4ff-d92b-1556" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="000b-c425-9bf7-5b7f" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f29a-ab96-28e9-418f" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="3d68-1852-4440-fee8" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-        <modifier type="increment" field="f9c3-2f0c-aaa8-d2f9" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="06c0-22ec-48c3-d1e1" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-      </modifiers>
-    </entryLink>
+    <entryLink id="2766-7ea3-4ff6-91b8" name="Mordor War Catapult" hidden="false" collective="false" import="true" targetId="207d-1974-4adb-f1cc" type="selectionEntry"/>
+    <entryLink id="ac46-4b45-381b-e2ed" name="Mordor Siege Bow" hidden="false" collective="false" import="true" targetId="68ba-fce7-8f51-b34d" type="selectionEntry"/>
   </entryLinks>
   <rules>
     <rule id="3afa-d5de-5cfd-af32" name="Bring the City to its Knees" publicationId="5d2d-eaa5-64b5-2f28" hidden="false">

--- a/Lindon.cat
+++ b/Lindon.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="08d0-1ea8-df00-37b0" name="Lindon" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="08d0-1ea8-df00-37b0" name="Lindon" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="6710-20d8-61b8-3721" name="Gil-Galad&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -73,6 +73,15 @@
         <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="9f84-7bf8-6d68-9005" name="Glofindel&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="b97e-bc6a-90c1-aacb" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="739e-8758-1bfe-ba4d" name="Glorfindel, Lord of the West" hidden="false" collective="false" import="true" targetId="20e9-e8bd-c470-7158" type="selectionEntry"/>
+        <entryLink id="ea38-26a6-798f-d57f" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>

--- a/Lothlórien.cat
+++ b/Lothlórien.cat
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a31e-11b5-5c65-f6c4" name="Lothlórien" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a31e-11b5-5c65-f6c4" name="Lothlórien" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="7b4d-b1b8-ed00-b553" name="Galadriel&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
         <categoryLink id="3375-c5d0-65e1-66c1" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+        <categoryLink id="8290-a984-d917-ab42" name="Galadriel" hidden="false" targetId="fc90-82e8-bbeb-e33a" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="f4d0-501b-726a-c403" name="Galadriel" hidden="false" collective="false" import="true" targetId="49e4-f047-d567-7b4b" type="selectionEntry"/>
@@ -19,6 +20,7 @@
     <selectionEntry id="a38b-42d0-507a-f9bb" name="Celeborn&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
         <categoryLink id="0881-bafc-283a-e639" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="10be-71f8-1ed4-9cf1" name="Celeborn" hidden="false" targetId="9f22-c30a-4d63-7fd7" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="89b2-306c-90ff-0997" name="Celeborn, Lord of Lothlórien" hidden="false" collective="false" import="true" targetId="5bb9-aa8d-fb0a-4e4b" type="selectionEntry"/>
@@ -75,6 +77,24 @@
         <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="61b0-e435-48fc-73c5" name="Rúmil&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="06cc-6086-dfd8-b85a" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="1fc7-a014-2656-0e24" name="Rúmil, Warden of Caras Galadhon" hidden="false" collective="false" import="true" targetId="8e3f-6e64-f9a7-cbde" type="selectionEntry"/>
+        <entryLink id="005e-6094-7856-1295" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="5ad5-509c-26a3-dbd4" name="Orophin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="a399-293f-8f57-cf53" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="ca0c-25c1-a68c-ad21" name="Orophin, Galadhrim Captain" hidden="false" collective="false" import="true" targetId="0ed0-6c99-e27b-642f" type="selectionEntry"/>
+        <entryLink id="c90c-3718-e4e6-0415" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>

--- a/Men of the West.cat
+++ b/Men of the West.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="f54e-7cad-1b7c-a99e" name="Men of the West" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="f54e-7cad-1b7c-a99e" name="Men of the West" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="99c6-9438-4a4a-6c6f" name="Aragorn&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -136,6 +136,97 @@
         <entryLink id="fc65-a23b-97e7-bcb0" name="Captain of Rohan" hidden="false" collective="false" import="true" targetId="4299-42b8-c5ec-79e4" type="selectionEntry"/>
         <entryLink id="ee1b-8659-acb3-d29c" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
       </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7e32-af79-920a-bab2" name="Beregond&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="38a5-61ab-5e6b-6d33" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="906e-2038-46a9-29ff" name="Beregond, Guard of the Citadel" hidden="false" collective="false" import="true" targetId="1357-3b3e-f0ba-3cca" type="selectionEntry"/>
+        <entryLink id="2436-1741-2220-b748" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="10f5-6bae-d5c8-c842" name="Captain of Dol Amroth&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="5345-edfd-7a0c-03f2" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="ff51-5414-f4a2-04d7" name="Captain of Dol Amroth" hidden="false" collective="false" import="true" targetId="ae1a-757f-80f3-b7de" type="selectionEntry"/>
+        <entryLink id="f3f5-d6b6-d849-7528" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a216-da1a-db0a-913e" name="Imrahil&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="0a75-1a4c-f942-dcfb" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="5b30-4048-f96e-62a8" name="Prince Imrahil of Dol Amroth" hidden="false" collective="false" import="true" targetId="7e3a-526d-1010-e0d9" type="selectionEntry"/>
+        <entryLink id="71f5-d8a9-de07-d728" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4f9e-2fa1-4623-54c9" name="Twin&apos;s Warbands" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="1fbd-f9fb-705a-633f" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="ea0f-a401-3747-c909" name="Twins" hidden="false" targetId="557f-c13b-ea47-c1a7" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b7e4-0388-6d1b-8b23" name="Elrohir&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="352d-d0e6-7fb2-4384" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="17e3-a173-4981-73c7" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6db3-5565-0add-2cc2" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+            <entryLink id="4339-d897-2148-f49a" name="Elrohir" hidden="false" collective="false" import="true" targetId="f6fc-d3c3-3b11-10ed" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+            <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+            <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+            <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="97d2-8a88-f892-0c3e" name="Elladan&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e4fc-3b3f-f9ae-f281" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="aa7f-26ff-19ff-15f5" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="95ef-c918-0ff5-eaa1" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+            <entryLink id="2a38-6bbe-8ff1-3782" name="Elladan" hidden="false" collective="false" import="true" targetId="6008-3674-8dd1-fcd6" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+            <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+            <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+            <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <costs>
         <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
         <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>

--- a/Minas Morgul.cat
+++ b/Minas Morgul.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="083c-50d2-89a7-e73f" name="Minas Morgul" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="8" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="083c-50d2-89a7-e73f" name="Minas Morgul" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="58c1-2bd1-b9c4-92fe" name="Witch-king&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -87,6 +87,15 @@
         <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="2986-917b-0e12-331d" name="Shaman&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="f41e-832b-8f2f-e7aa" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="2bc1-fae4-637d-db6c" name="Mordor Orc Shaman" hidden="false" collective="false" import="true" targetId="4211-61ca-c28b-c103" type="selectionEntry"/>
+        <entryLink id="508a-7eb6-e736-486c" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
     </selectionEntry>
   </selectionEntries>
   <entryLinks>

--- a/Minas Tirith.cat
+++ b/Minas Tirith.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d9c9-1ecb-df78-95c7" name="Minas Tirith" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="d9c9-1ecb-df78-95c7" name="Minas Tirith" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="b92b-ec03-a564-e58c" name="Denethor&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -81,5 +81,35 @@
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="e4bc-814f-1078-1d41" name="Ingold&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="af26-77fe-bb09-391a" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="1be2-5831-ca5d-c044" name="Ingold, Warden of the Rammas Echor" hidden="false" collective="false" import="true" targetId="fda1-fc6b-219b-51a2" type="selectionEntry"/>
+        <entryLink id="1ed3-ee38-04b0-2ca2" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="e1ce-1735-8190-bc34" name="Húrin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="5ba1-1eca-4fb7-a203" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="0fd1-f73e-1389-773d" name="Húrin the tall, Warden of the Keys" hidden="false" collective="false" import="true" targetId="9517-25f7-8439-f5c4" type="selectionEntry"/>
+        <entryLink id="de2a-1dfa-c94a-ec68" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="3804-dd4d-6992-4021" name="Beregond&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="076f-98e4-5ece-fa73" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="ab59-8081-3185-aad6" name="Beregond, Guard of the Citadel" hidden="false" collective="false" import="true" targetId="1357-3b3e-f0ba-3cca" type="selectionEntry"/>
+        <entryLink id="247f-7143-cd18-8505" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
   </selectionEntries>
+  <entryLinks>
+    <entryLink id="31f5-c14e-42c2-5e06" name="Gondor Avenger Bolt Thrower" hidden="false" collective="false" import="true" targetId="6853-fe9e-ea61-3850" type="selectionEntry"/>
+  </entryLinks>
 </catalogue>

--- a/Moria.cat
+++ b/Moria.cat
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="9b73-8d94-bcdb-4200" name="Moria" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="982f-f7ef-10a8-61cf" name="Durbûrz&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="ed28-157d-77f8-7845" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="441c-a92a-f8d0-413a" name="Durbûrz, Goblin-king of Moria" hidden="false" collective="false" import="true" targetId="487e-d3bb-23fc-8f7a" type="selectionEntry"/>
+        <entryLink id="bbdf-7e84-ea1a-2419" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9da7-9d5f-6c7a-7014" name="Shaman&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="bc39-c0d3-1938-be41" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="54da-8959-7c01-c218" name="Moria Goblin Shaman" hidden="false" collective="false" import="true" targetId="08fb-c2ef-0811-bfba" type="selectionEntry"/>
+        <entryLink id="71ca-b7b9-9bfd-127e" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c101-34f9-2d3f-8b5c" name="Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="8548-e28e-1949-b7cf" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="76c7-8a78-80f1-1a97" name="Moria Goblin Captain" hidden="false" collective="false" import="true" targetId="be58-9759-de81-8d67" type="selectionEntry"/>
+        <entryLink id="a1c5-1f53-4b02-2f85" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f42b-ebfb-268e-324a" name="Drûzhag&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="ab45-6a8c-f3d5-9560" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="3d09-74a3-33ed-948f" name="Beast" hidden="false" targetId="185c-07da-d0a7-1849" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="c0f2-9643-1890-1599" name="Drûzhag, the Beastcaller" hidden="false" collective="false" import="true" targetId="afe1-301d-11ee-2ecf" type="selectionEntry"/>
+        <entryLink id="b220-e191-bb88-6a93" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="585c-e720-ae14-de61" name="Drake&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="9130-9e23-0175-a248" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="d2f1-42c1-409d-49dd" name="Cave Drake" hidden="false" collective="false" import="true" targetId="3863-7e13-dffc-e8d0" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1b37-69e8-6e24-d5d4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6ba5-d252-88f6-abdb" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="b501-6bbd-4826-09f3" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="302b-d593-9732-42b8" name="Dragon&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="97b8-d987-41d6-7de2" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="d99b-5b86-670a-cce7" name="Dragon" hidden="false" collective="false" import="true" targetId="4203-5f4e-fdfd-53a7" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="7306-cd83-a3c3-05ec" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="2ba1-4c0f-4abc-f617" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="f3c3-7290-049f-b496" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink id="a70c-fe67-0a48-2fba" name="The Watcher in the Water" hidden="false" collective="false" import="true" targetId="7943-ab4e-a479-3c6d" type="selectionEntry"/>
+  </entryLinks>
+  <rules>
+    <rule id="0093-9420-69c4-56db" name="Durbûrz&apos;s Will" publicationId="8e2e-f1ed-1aa8-11ca" page="165" hidden="false">
+      <description>Once per game, at the start of his Activation, Durbûrz may declare he is using this ability. If he does, Durbûrz may not Move during his Activation; however, all friendly Moria Goblin models gain a bonus of +2&quot; to their Move Value until the End Phase of the turn. Additionally, in a turn in which Durbûrz uses this ability, all friendly Moria Goblin models within 6&quot; of him automatically pass any Courage Tests require when attempting to Charge a model with the Terror special rule.</description>
+    </rule>
+    <rule id="b2fa-8297-3edb-1e31" name="Skittering Warriors" publicationId="8e2e-f1ed-1aa8-11ca" page="165" hidden="false">
+      <description>Friendly Moria Goblin models gain the Mountain Dweller special rule.</description>
+    </rule>
+    <rule id="f058-de14-8a66-5d6b" name="&quot;We cannot get out, they are coming&quot;" publicationId="8e2e-f1ed-1aa8-11ca" page="165" hidden="false">
+      <description>Friendly Moria Goblin models Engaged in Combat with an enemy model that would be condsidered Trapped gain a bonus of +1 to their Fight Value for the duration of the Combat.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/Muster of Isengard.cat
+++ b/Muster of Isengard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="24a6-3259-2d77-5b47" name="Muster of Isengard" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="14" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="24a6-3259-2d77-5b47" name="Muster of Isengard" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="4972-d131-498a-506e" name="Saruman&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -49,6 +49,15 @@
         <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="e9f7-e6c5-bd75-0379" name="Shaman&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="acb5-a711-3a5e-79cf" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="0ad8-f1bf-d590-8eea" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+        <entryLink id="9a4c-6f29-e7f9-0b46" name="Uruk-hai Shaman" hidden="false" collective="false" import="true" targetId="93cc-ef43-4615-436b" type="selectionEntry"/>
+      </entryLinks>
     </selectionEntry>
   </selectionEntries>
   <entryLinks>

--- a/Paths of the Drúadan.cat
+++ b/Paths of the Drúadan.cat
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="79a9-7b84-4577-69c9" name="Paths of the Drúadan" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="0888-2567-f91b-40b3" name="Théoden&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0bc7-5fda-c0db-cb18" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="ef47-fd50-462d-e401" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+        <categoryLink id="314d-8e27-42d7-cee2" name="Rohan Royal Guard" hidden="false" targetId="3414-6388-2318-1371" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="59c3-6d5c-dc31-7f7d" name="Théoden, King of Rohan" hidden="false" collective="false" import="true" targetId="f1c7-d9e9-1b15-254b" type="selectionEntry"/>
+        <entryLink id="161f-c359-46d2-675c" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a3aa-55f0-3077-bbb4" name="Gamling&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="370e-94dc-9fd0-feae" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="9574-7e10-a33a-a7ea" name="Rohan Royal Guard" hidden="false" targetId="3414-6388-2318-1371" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="245a-6cea-9547-344a" name="Gamling, Captain of Rohan" hidden="false" collective="false" import="true" targetId="47ca-767f-a729-9f24" type="selectionEntry"/>
+        <entryLink id="68a5-5c30-d493-3e40" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a6f5-3707-6cfa-7cb5" name="Éomer&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="0274-95b0-1573-78c2" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="ef96-b977-dbe0-fa6e" name="Rohan Royal Guard" hidden="false" targetId="3414-6388-2318-1371" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="edd4-0f0c-3204-0f34" name="Éomer, Marshal of the Riddermark" hidden="false" collective="false" import="true" targetId="16a7-271a-69c0-6b85" type="selectionEntry"/>
+        <entryLink id="3203-dc73-6554-9574" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="120c-892a-d493-bc09" name="Ghân-Buri-Ghân&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="811b-5728-f6aa-0ab1" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="d428-20e9-5fd0-8d2c" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="0a12-481c-1549-97a2" name="Drúadan" hidden="false" targetId="1e3a-27e0-d407-c820" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="7766-88e4-f556-3bbb" name="Ghân-Buri-Ghân" hidden="false" collective="false" import="true" targetId="eaab-bb94-31d7-61cb" type="selectionEntry"/>
+        <entryLink id="1073-daf0-db4a-2154" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="17a5-264d-852b-fe6e" name="Déorwine&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="335a-7eba-494f-15a9" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="172d-408c-1c30-6940" name="Rohan Royal Guard" hidden="false" targetId="3414-6388-2318-1371" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="f6ab-b892-fe4e-773f" name="Déorwine, Chief of the King&apos;s Knights" hidden="false" collective="false" import="true" targetId="fe95-b1c9-fb94-0b25" type="selectionEntry"/>
+        <entryLink id="e838-7788-222a-87ab" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="33f5-bc78-aa36-1c75" name="Elfhelm&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="d72d-5541-34ea-1aed" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="3719-60dd-8d07-269e" name="Elfhelm, Captain of Rohan" hidden="false" collective="false" import="true" targetId="a2b3-b7a5-8d8e-5a83" type="selectionEntry"/>
+        <entryLink id="688f-5228-ec57-ec7c" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8b91-4eb0-03fb-d3f9" name="Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="97f5-2990-2d72-3389" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="c4aa-9e60-8fac-8e9d" name="Captain of Rohan" hidden="false" collective="false" import="true" targetId="4299-42b8-c5ec-79e4" type="selectionEntry"/>
+        <entryLink id="3863-cc56-cf8d-603a" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink id="8734-0889-bf41-36f7" name="Éowyn, Shieldmaiden of Rohan" hidden="false" collective="false" import="true" targetId="b9a5-82a3-89d1-0913" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="ca09-18e6-43ac-4e7a" name="New CategoryLink" hidden="false" targetId="13f2-59a9-5a73-a03f" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+  </entryLinks>
+  <rules>
+    <rule id="3428-03e0-af7b-b591" name="Know All Paths" publicationId="8e2e-f1ed-1aa8-11ca" page="83" hidden="false">
+      <description>if, during the Declare Heroic Actions step of a Move Phase, both sides have declared a Heroic Move and a roll-off is required to see which side&apos;s Heroic Move happens first, this Army will gain a bonus to that roll. If they would normally win the roll-off on a 4+, they will instead win it on a 3+. If they would normally win the roll-off on a 1, 2 or 3, they will instead win the roll-off on a 1, 2, 3 or 4.</description>
+    </rule>
+    <rule id="6230-d75d-bc92-7f11" name="Kill Orc-folk" publicationId="8e2e-f1ed-1aa8-11ca" page="83" hidden="false">
+      <description>Friendly models may re-roll To Wound Rolls of a natural 1 when making Strikes against Orc, Goblin or Uruk-hai models.</description>
+    </rule>
+    <rule id="c1a1-0179-d977-c7ce" name="Waypoints" publicationId="8e2e-f1ed-1aa8-11ca" page="83" hidden="false">
+      <description>At the start of the game, after both sides have been deployed, you may place up to three 25mm Waypoint Markers anywhere on the battlefield. Whilst within 6&quot; of a friendly Waypoint Marker, friendly Rohan models don&apos;t suffer any penalties for Moving, or Charging, through Difficult Terrain.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/Rangers of Mirkwood.cat
+++ b/Rangers of Mirkwood.cat
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6e1c-2334-df06-f60c" name="Rangers of Mirkwood" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="8" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6e1c-2334-df06-f60c" name="Rangers of Mirkwood" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="d8cb-bb0f-be39-551d" name="Legolas&apos; Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
         <categoryLink id="d391-f114-5b9e-3373" name="Hero of Valour" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
         <categoryLink id="50f6-6b30-a59c-e1ce" name="Mirkwood" hidden="false" targetId="3899-38ec-3426-7d4d" primary="false"/>
+        <categoryLink id="95d1-b53c-9867-5d3b" name="Unique Elf" hidden="false" targetId="f325-0038-7296-f312" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="7672-e7ba-adb5-c932" name="Legolas Greenleaf, Prince of Mirkwood" hidden="false" collective="false" import="true" targetId="5eb3-48a0-6a31-e47c" type="selectionEntry">
@@ -25,6 +26,7 @@
       <categoryLinks>
         <categoryLink id="a62d-b5f2-af98-0802" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
         <categoryLink id="b49c-b9fa-9886-ab6b" name="Mirkwood" hidden="false" targetId="3899-38ec-3426-7d4d" primary="false"/>
+        <categoryLink id="770c-c098-9a6c-b315" name="Unique Elf" hidden="false" targetId="f325-0038-7296-f312" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="4e16-ac7e-27a7-efb7" name="Tauriel, Ranger of Mirkwood" hidden="false" collective="false" import="true" targetId="d618-4dd2-674f-d37f" type="selectionEntry">

--- a/Realms of Men.cat
+++ b/Realms of Men.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8c74-cce2-6e2e-723e" name="Realms of Men" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8c74-cce2-6e2e-723e" name="Realms of Men" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="a3c0-4e0a-6546-1a5f" name="King of Gondor&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -84,9 +84,14 @@
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9212-93a8-e58a-dd9b" name="Captain of Númenor&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="9212-93a8-e58a-dd9b" name="Captain of Númenor&apos;s Warband" hidden="true" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="385b-11ab-9091-d162" value="-1.0">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1f69-79b4-cc21-f62a" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="false">
           <conditions>
             <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1f69-79b4-cc21-f62a" type="equalTo"/>
           </conditions>
@@ -110,9 +115,14 @@
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="97ef-cb25-ae71-ec53" name="Captain of Arnor&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="97ef-cb25-ae71-ec53" name="Captain of Arnor&apos;s Warband" hidden="true" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="5aae-9667-7955-32ac" value="-1.0">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4b3a-c814-a424-3b72" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="false">
           <conditions>
             <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4b3a-c814-a424-3b72" type="equalTo"/>
           </conditions>
@@ -136,9 +146,14 @@
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d5a8-9df0-b38d-085b" name="Captsin of Rohan&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="d5a8-9df0-b38d-085b" name="Captain of Rohan&apos;s Warband" hidden="true" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="e5e3-cdbf-b5f6-8c48" value="-1.0">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ffba-eec3-a043-f2e8" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="false">
           <conditions>
             <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ffba-eec3-a043-f2e8" type="equalTo"/>
           </conditions>
@@ -162,8 +177,13 @@
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0d28-2ac4-8363-e5af" name="Captain of Minas Tirith&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="0d28-2ac4-8363-e5af" name="Captain of Minas Tirith&apos;s Warband" hidden="true" collective="false" import="true" type="upgrade">
       <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a3c0-4e0a-6546-1a5f" type="equalTo"/>
+          </conditions>
+        </modifier>
         <modifier type="set" field="5897-978f-00ee-e0ad" value="-1.0">
           <conditions>
             <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a3c0-4e0a-6546-1a5f" type="equalTo"/>
@@ -188,8 +208,13 @@
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9fa8-5b5e-feb9-1085" name="Captain of Dale&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="9fa8-5b5e-feb9-1085" name="Captain of Dale&apos;s Warband" hidden="true" collective="false" import="true" type="upgrade">
       <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="08d2-88bb-b949-e208" type="equalTo"/>
+          </conditions>
+        </modifier>
         <modifier type="set" field="32ff-84d8-e552-082b" value="-1.0">
           <conditions>
             <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="08d2-88bb-b949-e208" type="equalTo"/>
@@ -214,175 +239,65 @@
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="2d05-cb8b-4f05-1607" name="Captain of Dol Amroth&apos;s Warband" hidden="true" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a3c0-4e0a-6546-1a5f" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="ec51-3eff-07f0-dcbc" value="-1.0">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a3c0-4e0a-6546-1a5f" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ec51-3eff-07f0-dcbc" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="2703-b7cc-4ce3-b924" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="2435-827c-9d1a-f2d8" name="Gondor" hidden="false" targetId="b4ea-7715-d55b-7e78" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="5cfa-4280-37a5-1fc5" name="Captain of Dol Amroth" hidden="false" collective="false" import="true" targetId="ae1a-757f-80f3-b7de" type="selectionEntry"/>
+        <entryLink id="09e8-d0c8-1025-f735" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </selectionEntries>
   <entryLinks>
-    <entryLink id="25b0-d7ec-8d1f-b069" name="Gondor Battlecry Trebuchet" hidden="false" collective="false" import="true" targetId="7276-9a27-52dc-a7fa" type="selectionEntry">
+    <entryLink id="25b0-d7ec-8d1f-b069" name="Gondor Battlecry Trebuchet" hidden="true" collective="false" import="true" targetId="7276-9a27-52dc-a7fa" type="selectionEntry">
       <modifiers>
-        <modifier type="decrement" field="9969-ffcf-3b2f-4bf9" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ed0b-ed64-e184-4050" repeats="1" roundUp="false"/>
-          </repeats>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a3c0-4e0a-6546-1a5f" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
-      <modifierGroups>
-        <modifierGroup>
-          <modifiers>
-            <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d5a8-9df0-b38d-085b" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a3c0-4e0a-6546-1a5f" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9212-93a8-e58a-dd9b" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a3c0-4e0a-6546-1a5f" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0d28-2ac4-8363-e5af" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a3c0-4e0a-6546-1a5f" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97ef-cb25-ae71-ec53" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a3c0-4e0a-6546-1a5f" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9fa8-5b5e-feb9-1085" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a3c0-4e0a-6546-1a5f" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </modifierGroup>
-        <modifierGroup>
-          <modifiers>
-            <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="08d2-88bb-b949-e208" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="9969-ffcf-3b2f-4bf9" value="0.0">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a3c0-4e0a-6546-1a5f" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4b3a-c814-a424-3b72" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1f69-79b4-cc21-f62a" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="9969-ffcf-3b2f-4bf9" value="1.0">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ffba-eec3-a043-f2e8" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </modifierGroup>
-      </modifierGroups>
     </entryLink>
-    <entryLink id="a4fb-3b4d-d982-396e" name="Windlance" hidden="false" collective="false" import="true" targetId="ed0b-ed64-e184-4050" type="selectionEntry">
+    <entryLink id="a4fb-3b4d-d982-396e" name="Windlance" hidden="true" collective="false" import="true" targetId="ed0b-ed64-e184-4050" type="selectionEntry">
       <modifiers>
-        <modifier type="decrement" field="28da-e67b-b4f3-0a62" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7276-9a27-52dc-a7fa" repeats="1" roundUp="false"/>
-          </repeats>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="08d2-88bb-b949-e208" type="equalTo"/>
+          </conditions>
         </modifier>
       </modifiers>
-      <modifierGroups>
-        <modifierGroup>
-          <modifiers>
-            <modifier type="increment" field="28da-e67b-b4f3-0a62" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d5a8-9df0-b38d-085b" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="08d2-88bb-b949-e208" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="28da-e67b-b4f3-0a62" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9212-93a8-e58a-dd9b" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="08d2-88bb-b949-e208" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="28da-e67b-b4f3-0a62" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0d28-2ac4-8363-e5af" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="08d2-88bb-b949-e208" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="28da-e67b-b4f3-0a62" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97ef-cb25-ae71-ec53" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="08d2-88bb-b949-e208" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="28da-e67b-b4f3-0a62" value="1.0">
-              <repeats>
-                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9fa8-5b5e-feb9-1085" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="08d2-88bb-b949-e208" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </modifierGroup>
-        <modifierGroup>
-          <modifiers>
-            <modifier type="increment" field="28da-e67b-b4f3-0a62" value="1.0">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a3c0-4e0a-6546-1a5f" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="28da-e67b-b4f3-0a62" value="0.0">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="08d2-88bb-b949-e208" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="28da-e67b-b4f3-0a62" value="1.0">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4b3a-c814-a424-3b72" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="28da-e67b-b4f3-0a62" value="1.0">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1f69-79b4-cc21-f62a" type="equalTo"/>
-              </conditions>
-            </modifier>
-            <modifier type="increment" field="28da-e67b-b4f3-0a62" value="1.0">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ffba-eec3-a043-f2e8" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </modifierGroup>
-      </modifierGroups>
+    </entryLink>
+    <entryLink id="dbab-2cc0-65b4-7664" name="Gondor Avenger Bolt Thrower" hidden="true" collective="false" import="true" targetId="6853-fe9e-ea61-3850" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a3c0-4e0a-6546-1a5f" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
     </entryLink>
   </entryLinks>
   <rules>

--- a/Riders of Théoden.cat
+++ b/Riders of Théoden.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="67a1-f8cb-5b6d-6f13" name="Riders of Théoden" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="67a1-f8cb-5b6d-6f13" name="Riders of Théoden" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="6161-b5a5-a43b-41f2" name="Éomer&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -72,8 +72,43 @@
         <categoryLink id="efb3-2ea7-9379-36b0" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="aa03-235f-cc0d-d9e0" name="Éowyn, Shieldmaiden of Rohan" hidden="false" collective="false" import="true" targetId="b9a5-82a3-89d1-0913" type="selectionEntry"/>
+        <entryLink id="aa03-235f-cc0d-d9e0" name="Éowyn, Shieldmaiden of Rohan" hidden="false" collective="false" import="true" targetId="b9a5-82a3-89d1-0913" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ecf6-f242-2125-bb5d" type="min"/>
+          </constraints>
+        </entryLink>
         <entryLink id="12ab-6937-3ea3-2e47" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b54c-36c0-e46e-054a" name="Déorwine&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="b8bf-c039-ca9c-74b1" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="ae3b-b6b2-85a7-3693" name="New CategoryLink" hidden="false" targetId="3414-6388-2318-1371" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="15c4-d1c1-90f0-bb38" name="Déorwine, Chief of the King&apos;s Knights" hidden="false" collective="false" import="true" targetId="fe95-b1c9-fb94-0b25" type="selectionEntry"/>
+        <entryLink id="0393-685e-d2fb-1f84" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8194-87f2-dc4a-38fa" name="Elfhelm&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="87a4-02ed-af58-7bce" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="90b5-d093-7c8e-7e8d" name="Elfhelm, Captain of Rohan" hidden="false" collective="false" import="true" targetId="a2b3-b7a5-8d8e-5a83" type="selectionEntry"/>
+        <entryLink id="6481-18fa-86be-af10" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>

--- a/Rivendell.cat
+++ b/Rivendell.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0a14-85c6-3e84-b516" name="Rivendell" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0a14-85c6-3e84-b516" name="Rivendell" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="188f-e4f4-e484-338c" name="Elrond&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -68,6 +68,46 @@
         <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="b5e2-be0d-5e3e-42c4" name="Glorfindel&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="6b86-edcd-4724-9ef6" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="6953-7097-d69b-ab37" name="Glorfindel, Lord of the West" hidden="false" collective="false" import="true" targetId="20e9-e8bd-c470-7158" type="selectionEntry"/>
+        <entryLink id="3652-66bb-0031-0601" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="04b2-deed-7340-7ca0" name="Twin&apos;s Warbands" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="023d-64f1-3e2c-ed3e" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="1db0-1b42-e301-adea" name="Twins" hidden="false" targetId="557f-c13b-ea47-c1a7" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6b55-0aa7-73e5-e9f7" name="Elladan&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="971b-0827-42da-d976" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="135e-8b66-2359-4e43" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6745-a498-9964-27e9" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+            <entryLink id="78cf-71b8-b22b-6570" name="Elladan" hidden="false" collective="false" import="true" targetId="6008-3674-8dd1-fcd6" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntry>
+        <selectionEntry id="1ff3-65ee-a8e0-69fb" name="Elrohir&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="f56a-30d2-2a0c-635a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="5c46-d432-ee7b-895f" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="727b-f1bb-17b9-e76f" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+            <entryLink id="5d5b-f5cd-a86f-6865" name="Elrohir" hidden="false" collective="false" import="true" targetId="f6fc-d3c3-3b11-10ed" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="4cb2-1c62-3dab-1cd9" name="Twins Horses" hidden="false" collective="false" import="true" targetId="89cf-118e-6553-fded" type="selectionEntry"/>
+      </entryLinks>
     </selectionEntry>
   </selectionEntries>
   <entryLinks>

--- a/Road to Rivendell.cat
+++ b/Road to Rivendell.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="dade-d5e9-f01f-ae2a" name="Road to Rivendell" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="dade-d5e9-f01f-ae2a" name="Road to Rivendell" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="2390-53f6-82bd-79e1" name="Aragorn&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -122,6 +122,8 @@
         <categoryLink id="fd8e-199d-f766-a4a6" name="Independent Hero" hidden="false" targetId="13f2-59a9-5a73-a03f" primary="true"/>
       </categoryLinks>
     </entryLink>
+    <entryLink id="5ccc-01cb-30ab-595c" name="Tom Bombadil" hidden="false" collective="false" import="true" targetId="62bc-dfb7-6a09-9efb" type="selectionEntry"/>
+    <entryLink id="8462-2b0a-7203-31d9" name="Goldberry" hidden="false" collective="false" import="true" targetId="0ef4-6395-7c31-73c2" type="selectionEntry"/>
   </entryLinks>
   <rules>
     <rule id="2315-e8b4-72d1-530f" name="&quot;We do not stop &apos;til nightfall&quot;" publicationId="5d2d-eaa5-64b5-2f28" hidden="false">

--- a/Shadows of Angmar.cat
+++ b/Shadows of Angmar.cat
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="1108-7d85-e40e-ee4d" name="Shadows of Angmar" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="5" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="1108-7d85-e40e-ee4d" name="Shadows of Angmar" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="e5f9-2c2d-63d1-4b64" name="Gûlavhar&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
-      <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="76be-9f68-b566-fe8a" type="min"/>
-      </constraints>
       <categoryLinks>
         <categoryLink id="747a-79b8-8170-1362" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
       </categoryLinks>

--- a/Sharkey's Rogues.cat
+++ b/Sharkey's Rogues.cat
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="3c3e-5efb-2b43-438f" name="Sharkey&apos;s Rogues" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="1a50-6bc1-9080-b9c8" name="Sharkey&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e3fb-9648-5148-b0d4" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="b2f6-84b7-b579-4f65" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="abbc-5b32-0b47-6089" name="Sharkey" hidden="false" collective="false" import="true" targetId="12fc-e785-8f3d-3748" type="selectionEntry"/>
+        <entryLink id="459c-4734-716f-8503" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fc29-8964-10dd-6003" name="Rowan&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="36bd-6dbc-1880-c15e" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="c292-aad7-a37b-eb91" name="Rowan Thistlewood" hidden="false" collective="false" import="true" targetId="ee81-3bd2-4325-30f5" type="selectionEntry"/>
+        <entryLink id="102a-f0c7-6069-a32d" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fbed-12ac-5486-92cd" name="Sid&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="5716-202f-e727-51ea" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="4d34-9d80-8b31-30b8" name="Sid Briarthorn" hidden="false" collective="false" import="true" targetId="2ea8-a070-d497-636b" type="selectionEntry"/>
+        <entryLink id="1b37-2619-77ab-fdfc" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="92c3-7deb-48e5-8b7f" name="Bill&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="4a92-dd2f-6cf3-ec44" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="ff8d-8217-699f-66c0" name="Bill Ferny" hidden="false" collective="false" import="true" targetId="93e6-c71c-053c-46aa" type="selectionEntry"/>
+        <entryLink id="258f-a9e9-f773-5078" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e497-b09d-87dd-aff6" name="Lotho&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="ca41-59b2-ca05-b274" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="0c4a-1e34-6a6c-6a3e" name="Hobbit" hidden="false" targetId="77b6-9c8a-1084-c3b6" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="4c39-fd89-353e-7ce2" name="Lotho Sackville-Baggins" hidden="false" collective="false" import="true" targetId="f981-ce3d-6134-5bc5" type="selectionEntry"/>
+        <entryLink id="d715-61f8-8e8a-2148" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="19b4-0dff-09d1-d837" name="Ted&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="e426-ef16-d792-958f" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="225b-e15d-5e2f-b66e" name="Hobbit" hidden="false" targetId="77b6-9c8a-1084-c3b6" primary="false"/>
+        <categoryLink id="cb67-fee9-8480-d055" name="Ted" hidden="false" targetId="f548-0151-28e2-8fdc" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="f512-93dc-6271-bdca" name="Ted Sandyman" hidden="false" collective="false" import="true" targetId="46ad-9dc9-92e8-8374" type="selectionEntry"/>
+        <entryLink id="90e8-e2e5-862a-3c67" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8e7a-7edd-c857-e22b" name="Heroless Warband" hidden="true" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="6187-53ab-a696-77c1" value="-1.0">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="92c3-7deb-48e5-8b7f" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fc29-8964-10dd-6003" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="19b4-0dff-09d1-d837" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1a50-6bc1-9080-b9c8" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fbed-12ac-5486-92cd" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e497-b09d-87dd-aff6" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" field="hidden" value="false">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="92c3-7deb-48e5-8b7f" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fc29-8964-10dd-6003" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="19b4-0dff-09d1-d837" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1a50-6bc1-9080-b9c8" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fbed-12ac-5486-92cd" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e497-b09d-87dd-aff6" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6187-53ab-a696-77c1" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="6b89-519d-4c82-a244" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="f67f-7b47-ae35-c46d" name="Warrior" hidden="false" targetId="db62-064c-861f-a340" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="8b07-e244-b677-d9af" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup">
+          <constraints>
+            <constraint field="5141-e5a1-1d1f-e715" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="a1c9-e972-8603-4c62" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <rules>
+    <rule id="0c8b-13db-138d-76ce" name="&quot;You do what Sharkey says!&quot;" publicationId="8e2e-f1ed-1aa8-11ca" page="163" hidden="false">
+      <description>Sharkey&apos;s Stand Fast will cover the entire battlefield, regardless of range.</description>
+    </rule>
+    <rule id="3884-f4f8-7b0d-f1f1" name="Strength in Numbers" publicationId="8e2e-f1ed-1aa8-11ca" page="163" hidden="false">
+      <description>Whilst this Army is not Broken, friendly Ruffian models gain a +1 bonus to any Courage Tests they are required to take.</description>
+    </rule>
+    <rule id="a481-316d-9655-8a97" name="The Wizard&apos;s Command" publicationId="8e2e-f1ed-1aa8-11ca" page="163" hidden="false">
+      <description>Friendly Ruffian models within 6&quot; of Sharkey may use his Courage instead of their own when taking Courage Tests.</description>
+    </rule>
+    <rule id="605d-c324-6162-0a0f" name="Sharkey&apos;s Wrath" publicationId="8e2e-f1ed-1aa8-11ca" page="163" hidden="false">
+      <description>Sharkey gains the Hatred (Hobbit) special rule.</description>
+    </rule>
+    <rule id="0d92-ae29-9517-fb59" name="The Chief&apos;s Whips" publicationId="8e2e-f1ed-1aa8-11ca" page="163" hidden="false">
+      <description>Friendly Ruffian models gain a bonus of +1 To Hit when making a shooting attack with a whip.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/The Beornings.cat
+++ b/The Beornings.cat
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="8d3c-ae7d-8746-b42a" name="The Beornings" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="2287-f7c4-a974-0447" name="Beorn&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="d8de-3700-1f0e-2418" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="d662-7b23-a8a4-03d9" name="Beorn" hidden="false" collective="false" import="true" targetId="6ed6-e341-55ad-6389" type="selectionEntry"/>
+        <entryLink id="5153-1feb-abc7-18ad" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="c278-a86c-a505-df42" name="Grimbeorn&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="fdf1-b83e-77b8-6e7f" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="0c26-e739-a150-5ca0" name="Grimbeorn" hidden="false" collective="false" import="true" targetId="4713-e3ce-c761-9b18" type="selectionEntry"/>
+        <entryLink id="1e57-179f-d6b1-091c" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+  </selectionEntries>
+  <rules>
+    <rule id="95a6-b539-1238-87c8" name="Great Resilience" publicationId="8e2e-f1ed-1aa8-11ca" hidden="false">
+      <description>Whenever a friendly Bear model suffers a Wound, roll a D6. On the roll of a natural 6, the Wound is ignored.</description>
+    </rule>
+    <rule id="a196-a69f-850f-3f9b" name="Natural Resistance" publicationId="8e2e-f1ed-1aa8-11ca" hidden="false">
+      <description>Friendly models gain the Resistant to Magic special rule.</description>
+    </rule>
+    <rule id="4da6-4b3a-be60-b280" name="Ursine Fury" publicationId="8e2e-f1ed-1aa8-11ca" hidden="false">
+      <description>At the beginning of each Move Phase, before the Declare Heroic Action step, you may roll a D6 for each friendly Bear model you have on the battlefield. If any of the D6 roll a natural 6, then for the duration of the turn enemy models suffer a -1 penalty to any Courage Tests they are required to take as a result of trying to Charge a model with the Terror special rule.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/The Black Gate.cat
+++ b/The Black Gate.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="75b4-5ec5-6896-b88d" name="The Black Gate" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="75b4-5ec5-6896-b88d" name="The Black Gate" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="7710-aa28-4041-d8b4" name="Mouth&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -100,6 +100,15 @@
         <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="b406-508d-5cd2-a67f" name="Shaman&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="c503-b36a-d355-43e2" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="7a09-b0a3-90de-ec53" name="Mordor Orc Shaman" hidden="false" collective="false" import="true" targetId="4211-61ca-c28b-c103" type="selectionEntry"/>
+        <entryLink id="4904-4c6a-2c4c-a236" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>

--- a/The Easterlings.cat
+++ b/The Easterlings.cat
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="4830-05b2-51f4-c528" name="The Easterlings" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="5d83-17f0-1e08-ec8b" name="Priest&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="d782-0b7a-7472-72a7" name="Hero of Fortitude" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="9bc0-5905-7dbe-bcea" name="Easterling War Priest" hidden="false" collective="false" import="true" targetId="0895-8943-5206-d301" type="selectionEntry"/>
+        <entryLink id="47de-28c2-30c8-9f29" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="e2fc-f20a-ab0b-ef60" name="Infantry Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="88a0-65d7-c743-0604" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="60e5-7bcc-1529-5b88" name="Easterling Captain" hidden="false" collective="false" import="true" targetId="dbb7-1ded-4dfc-def8" type="selectionEntry"/>
+        <entryLink id="8c39-052b-f320-53f8" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="7a12-68bd-f576-8dd0" name="Kataphrakt Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="39ff-719a-e840-ade7" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="96d3-587d-5358-a820" name="Easterling Kataphrakt Captain" hidden="false" collective="false" import="true" targetId="0156-7c08-a86f-275b" type="selectionEntry"/>
+        <entryLink id="4f57-399b-8054-2407" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="94e0-ce62-ff57-c38e" name="Knight&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="c4ae-41f4-caa2-4eb2" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+        <categoryLink id="2ebc-3e24-4c8e-f4ee" name="Black Dragon" hidden="false" targetId="4a72-9b0e-9a1c-3881" primary="false"/>
+        <categoryLink id="e10d-35ae-820a-af1b" name="Dragon Knight" hidden="false" targetId="efee-4410-dfee-f34d" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="5e9a-ab7e-d7dd-8b01" name="Easterling Dragon Knight" hidden="false" collective="false" import="true" targetId="25c2-59ac-2b5d-e41d" type="selectionEntry"/>
+        <entryLink id="f3a3-8720-76b1-516b" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="a0f7-9520-228e-9372" name="Amdûr&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e8a3-224a-deb1-803e" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="7049-db9a-95aa-8497" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="d630-2253-744d-e7eb" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="0858-a7a0-82bb-50d2" name="Black Dragon" hidden="false" targetId="4a72-9b0e-9a1c-3881" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="411b-553c-ab04-adda" name="Amdûr, Lord of Blades" hidden="false" collective="false" import="true" targetId="a3ab-6fbd-b823-7bfd" type="selectionEntry"/>
+        <entryLink id="19a3-8423-13c6-2551" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+  </selectionEntries>
+  <rules>
+    <rule id="7aaa-5a63-94b6-d65b" name="No quarter was asked..." publicationId="8e2e-f1ed-1aa8-11ca" page="179" hidden="false">
+      <description>Friendly Easterling models gain a bonus of +1 to any Courage Tests they are required to take once their Army is Broken. Additionally, once per game in Scenarios in which a dice is rolled to see when the game ends, you may choose to have the dice re-rolled if the Scenario ends before you wish it to.</description>
+    </rule>
+    <rule id="77f6-3cc3-95a8-a13d" name="Press the advantage" publicationId="8e2e-f1ed-1aa8-11ca" page="179" hidden="false">
+      <description>Whilst the enemy Army is Broken, friendly Easterling Hero models gain the Fearless special rule.</description>
+    </rule>
+    <rule id="7de4-69e5-fd86-b0f1" name="Raze the White City" publicationId="8e2e-f1ed-1aa8-11ca" page="179" hidden="false">
+      <description>Friendly models gain the Ancient Enemies (Gondor) special rule.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/The Fiefdoms.cat
+++ b/The Fiefdoms.cat
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="f95c-2a4f-4475-eb32" name="The Fiefdoms" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="5607-c427-06cd-706d" name="Imrahil&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="3769-b4bf-6445-6ee0" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="b399-6604-a417-90e0" name="Prince Imrahil of Dol Amroth" hidden="false" collective="false" import="true" targetId="7e3a-526d-1010-e0d9" type="selectionEntry"/>
+        <entryLink id="9e3b-5189-0c2a-b103" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="068e-9386-bac5-f9fe" name="Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="1602-93f0-38c0-bb44" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="21b3-66ef-40c0-f94d" name="Captain of Dol Amroth" hidden="false" collective="false" import="true" targetId="ae1a-757f-80f3-b7de" type="selectionEntry"/>
+        <entryLink id="11da-b5da-4802-a3c8" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="dc79-995f-123e-26cc" name="Forlong&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="8334-b271-a15d-f912" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="cb76-0cb3-0491-4f6b" name="Forlong the Fat" hidden="false" collective="false" import="true" targetId="a7c2-f660-d0d7-491a" type="selectionEntry"/>
+        <entryLink id="b5b8-5041-362d-b711" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="441c-a090-e6de-ac89" name="Duinhir&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="990f-a142-38d4-30fb" name="Hero of Valour" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="a13b-4221-a4da-e640" name="Blackroot Vale" hidden="false" targetId="9d84-50de-9981-dd30" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="252e-a1d8-c1fa-a0ae" name="Duinhir, Lord of the Blackroot Vale" hidden="false" collective="false" import="true" targetId="ed04-c308-74ce-9787" type="selectionEntry"/>
+        <entryLink id="d55f-1f57-8cbf-b4f1" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="7e29-dc28-6392-7831" name="Angbor&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="c851-26f1-22c2-5c0b" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="cd94-45d9-a90f-49ae" name="Angbor the Fearless" hidden="false" collective="false" import="true" targetId="5c2e-552b-8384-6e49" type="selectionEntry"/>
+        <entryLink id="24b6-e61b-dba5-bb03" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+  </selectionEntries>
+  <rules>
+    <rule id="0d20-11d5-9d0f-905f" name="Leaders of the the Fiefdoms" publicationId="8e2e-f1ed-1aa8-11ca" hidden="false">
+      <description>If a friendly Hero Charges into Combat, then during the Fight Phase, friendly Infantry models within 6&quot; of the Hero that share both of the same Faction Keywords as the Hero gain an additional +1 bonus To Wound when making Strikes.</description>
+    </rule>
+    <rule id="6848-241b-709f-4d25" name="&quot;For the White City!&quot;" publicationId="8e2e-f1ed-1aa8-11ca" hidden="false">
+      <description>The first turn in which this Army would be Broken and therefore have to take Courage Tests as a result of being a Broken Army, all friendly models will automaically pass Courage Tests for being Broken that turn.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/The Grey Company.cat
+++ b/The Grey Company.cat
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="ac2c-1e03-cb1d-b173" name="The Grey Company" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="c366-c3dc-b4f7-20b1" name="Elladan &amp; Elrohir" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="bcb1-79f4-d384-84a7" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="eabe-9929-6054-3595" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="9cf8-0356-6a96-92d2" name="Elladan" hidden="false" collective="false" import="true" targetId="6008-3674-8dd1-fcd6" type="selectionEntry"/>
+        <entryLink id="ba9f-ecaf-14af-cafb" name="Elrohir" hidden="false" collective="false" import="true" targetId="f6fc-d3c3-3b11-10ed" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink id="e07e-507e-ba1f-4d14" name="Aragorn (Strider)" hidden="false" collective="false" import="true" targetId="a615-398c-c397-a883" type="selectionEntry">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="3e7c-421d-404f-0c64" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="5177-959d-7ed8-373b" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="b5e7-6ba8-638e-f49e" name="Legolas Greenleaf" hidden="false" collective="false" import="true" targetId="0f6a-50ca-f061-004e" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="19b8-7e4f-b4e2-4811" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="2260-d50e-4056-7b25" name="Gimli, Son of Glóin" hidden="false" collective="false" import="true" targetId="4072-d158-632b-17b9" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="9d04-1d53-9636-e1e9" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="57cc-6ee4-42c5-1d03" name="Halbarad" hidden="false" collective="false" import="true" targetId="4431-2a2c-a316-01b8" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="4bc0-a283-3db8-2613" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="59f1-a7e4-cc22-52e9" name="Ranger of the North" hidden="false" collective="false" import="true" targetId="314b-1db4-c42a-fa4f" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="c90b-924b-0f89-a007" name="New CategoryLink" hidden="false" targetId="13f2-59a9-5a73-a03f" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+  </entryLinks>
+  <rules>
+    <rule id="e5b2-2797-852f-1868" name="The Heir of Isildur" publicationId="8e2e-f1ed-1aa8-11ca" page="77" hidden="false">
+      <description>Aragorn does not have to pay any points for Andúril, Flame of the West; he automatically has this upgrade - it is free.</description>
+    </rule>
+    <rule id="8f29-8116-4c1a-3543" name="Masters of the Wild" publicationId="8e2e-f1ed-1aa8-11ca" page="77" hidden="false">
+      <description>Friendly models are not slowed by difficult terrain of any type.</description>
+    </rule>
+    <rule id="939e-9ab7-9495-07b8" name="&quot;They&apos;re dangerous folk, wandering the wilds&quot;" publicationId="8e2e-f1ed-1aa8-11ca" page="77" hidden="false">
+      <description>Rangers of the North increase their Attacks value to 2.</description>
+    </rule>
+    <rule id="3bd6-9ce6-8fe3-8091" name="Passing of the Grey Company" publicationId="8e2e-f1ed-1aa8-11ca" page="77" hidden="false">
+      <description>Rangers of the North may benefit from the Stand Fast of any friendly Unique Hero model.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/The Grief of Éomer.cat
+++ b/The Grief of Éomer.cat
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="214c-b4f0-6362-3419" name="The Grief of Éomer" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="09d5-4735-e6fc-0f92" name="Éomer&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e8f7-c401-1487-7603" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="1660-6e98-b547-4b26" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+        <categoryLink id="452e-4d31-0b75-58bc" name="Rohan" hidden="false" targetId="0d50-809e-7dc4-939a" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="f76c-f7eb-5ede-10a3" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+        <entryLink id="a36f-5e2a-9013-e3ca" name="Éomer, Marshal of the Riddermark" hidden="false" collective="false" import="true" targetId="16a7-271a-69c0-6b85" type="selectionEntry"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="ab1e-a7a2-c5d0-c1ef" name="Imrahil&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="b997-4cd7-c8f8-3ab2" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+        <categoryLink id="5012-1c87-5b87-5c7c" name="Gondor" hidden="false" targetId="b4ea-7715-d55b-7e78" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="dadb-f99c-65df-3d00" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+        <entryLink id="e870-7b7f-a0f8-c419" name="Prince Imrahil of Dol Amroth" hidden="false" collective="false" import="true" targetId="7e3a-526d-1010-e0d9" type="selectionEntry"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="9ea1-9243-4959-63a1" name="Húrin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="b8c7-5cd6-6422-3558" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="c8c1-fd4f-5a23-7cfa" name="Gondor" hidden="false" targetId="b4ea-7715-d55b-7e78" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="865d-c911-1851-0364" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+        <entryLink id="8dca-2840-9be1-7e7d" name="Húrin the tall, Warden of the Keys" hidden="false" collective="false" import="true" targetId="9517-25f7-8439-f5c4" type="selectionEntry"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="9b59-d524-3119-8181" name="Captain of Rohan&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="0b7d-7fde-ee85-7e29" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="7d66-549a-400d-ec61" name="Rohan" hidden="false" targetId="0d50-809e-7dc4-939a" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="69ca-45ad-8f9a-970b" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+        <entryLink id="aeca-1216-2ffd-26e4" name="Captain of Rohan" hidden="false" collective="false" import="true" targetId="4299-42b8-c5ec-79e4" type="selectionEntry"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="ff88-a4a4-8b55-32b5" name="Captain of Dol Amroth&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="ec7d-5c91-f364-b710" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="29e4-86fa-7a75-cf9b" name="Gondor" hidden="false" targetId="b4ea-7715-d55b-7e78" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="235c-38cd-992b-b0fc" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+        <entryLink id="cecf-8ae9-717c-ee06" name="Captain of Dol Amroth" hidden="false" collective="false" import="true" targetId="ae1a-757f-80f3-b7de" type="selectionEntry"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="28f1-b21b-bb59-d002" name="Captain of Minas Tirith&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="80ed-3842-0353-38cd" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="5789-4154-0a49-5369" name="Gondor" hidden="false" targetId="b4ea-7715-d55b-7e78" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="d635-bf66-258b-5007" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+        <entryLink id="6795-79b7-becc-d3c1" name="Captain of Minas Tirith" hidden="false" collective="false" import="true" targetId="93a2-881f-44d1-4302" type="selectionEntry"/>
+      </entryLinks>
+    </selectionEntry>
+  </selectionEntries>
+  <rules>
+    <rule id="3c40-161c-ab11-9dc9" name="Éomer&apos;s  Warth" publicationId="8e2e-f1ed-1aa8-11ca" page="87" hidden="false">
+      <description>Éomer is always treated as being under the effects of his The Price of Grief special rule. Additionally, Éomer gains a bonus of +1 to his Fight Value on a turn in which he Charges.</description>
+    </rule>
+    <rule id="47b2-586d-f4aa-c10a" name="Fear no enemy" publicationId="8e2e-f1ed-1aa8-11ca" page="87" hidden="false">
+      <description>Éomer gains the Fearless special rule. Additionally, friendly Rohan models that can draw Line of Sight to Éomer automatically pass any Courage Tests they are required to take.</description>
+    </rule>
+    <rule id="af5e-cebb-802a-1e71" name="Ride of Dol Amroth" publicationId="8e2e-f1ed-1aa8-11ca" page="87" hidden="false">
+      <description>Friendly Gondor models may re-roll To Wound Rolls of a natural 1 when making Strikes in a turn in which they Charged.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/The Iron Hills.cat
+++ b/The Iron Hills.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0aaf-4656-2f35-8feb" name="The Iron Hills" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0aaf-4656-2f35-8feb" name="The Iron Hills" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="64b3-e316-b577-d8ac" name="Dáin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -22,6 +22,7 @@
     <selectionEntry id="dca5-65fb-9ed7-c04d" name="King&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
         <categoryLink id="d2f6-537e-76da-ca83" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="e12b-3909-f68c-6965" name="Iron Hills" hidden="false" targetId="588f-968a-8fc9-1db7" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="aea6-65dc-d103-a0e2" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
@@ -51,25 +52,7 @@
     </selectionEntry>
   </selectionEntries>
   <entryLinks>
-    <entryLink id="865a-77ed-8d42-fa11" name="Iron Hills Ballista" hidden="false" collective="false" import="true" targetId="3d27-1ac1-47c7-3ce3" type="selectionEntry">
-      <modifiers>
-        <modifier type="increment" field="180a-f41f-2b40-1a3a" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dca5-65fb-9ed7-c04d" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="180a-f41f-2b40-1a3a" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9cdf-2b4e-845c-736b" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-        <modifier type="increment" field="180a-f41f-2b40-1a3a" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="64b3-e316-b577-d8ac" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-    </entryLink>
+    <entryLink id="865a-77ed-8d42-fa11" name="Iron Hills Ballista" hidden="false" collective="false" import="true" targetId="3d27-1ac1-47c7-3ce3" type="selectionEntry"/>
   </entryLinks>
   <rules>
     <rule id="a6a5-be14-bb5e-e8d4" name="&quot;Ironfoot has come!&quot;" publicationId="a40a-1ac4-b5c2-a481" page="57" hidden="false">

--- a/The Last Alliance.cat
+++ b/The Last Alliance.cat
@@ -1,20 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="48ac-227e-e93d-2844" name="The Last Alliance" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="48ac-227e-e93d-2844" name="The Last Alliance" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="2ea0-037a-dc40-b770" name="Elendil&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="1a3b-de1f-c6ba-47d5" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="730f-ac21-475c-bc2a" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1a3b-de1f-c6ba-47d5" type="min"/>
-      </constraints>
       <categoryLinks>
         <categoryLink id="dac3-ef59-4545-d005" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
         <categoryLink id="4535-f4cb-2277-6fb0" name="Númenor" hidden="false" targetId="734e-e20e-e60f-72ec" primary="false"/>
+        <categoryLink id="11e0-28c0-f0df-b322" name="Unique Númenor" hidden="false" targetId="9857-d271-aaa7-38d6" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="c2f3-aa55-13a4-2744" name="Elendil, High King of Gondor and Arnor" hidden="false" collective="false" import="true" targetId="e499-8560-efa7-5676" type="selectionEntry"/>
@@ -28,19 +19,10 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="88bb-178a-2f91-0272" name="Gil-Galad&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="f5c9-22d9-702a-6792" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0dc4-ee21-ac34-490a" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="f5c9-22d9-702a-6792" type="min"/>
-      </constraints>
       <categoryLinks>
         <categoryLink id="3eca-0391-19ff-e487" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
         <categoryLink id="4d4b-2b3f-d7b9-088e" name="Rivendell" hidden="false" targetId="eec7-0c18-5168-1229" primary="false"/>
+        <categoryLink id="5960-93f9-c461-0cf3" name="Unique Rivendell" hidden="false" targetId="b3f9-6c12-2610-17b5" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="de06-cd9a-05e2-05e9" name="Gil-Galad, High King of the Noldor" hidden="false" collective="false" import="true" targetId="ced9-2c70-14cb-a7a3" type="selectionEntry"/>
@@ -70,19 +52,10 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="0dc4-ee21-ac34-490a" name="Elrond&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="019d-c6bc-9231-8516" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="88bb-178a-2f91-0272" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="019d-c6bc-9231-8516" type="min"/>
-      </constraints>
       <categoryLinks>
         <categoryLink id="25b5-faf3-d2f4-1800" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
         <categoryLink id="1e90-a489-0d3a-4cad" name="Rivendell" hidden="false" targetId="eec7-0c18-5168-1229" primary="false"/>
+        <categoryLink id="1303-dd7f-a38b-2e9b" name="Unique Rivendell" hidden="false" targetId="b3f9-6c12-2610-17b5" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="c43d-5d45-1cb0-1a8b" name="Elrond, Master of Rivendell" hidden="false" collective="false" import="true" targetId="5126-1b1a-3e92-b853" type="selectionEntry">
@@ -100,19 +73,10 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="730f-ac21-475c-bc2a" name="Isildur&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="6b38-166c-4941-1a44" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2ea0-037a-dc40-b770" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6b38-166c-4941-1a44" type="min"/>
-      </constraints>
       <categoryLinks>
         <categoryLink id="9cf5-1e99-be16-60ff" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
         <categoryLink id="e865-2860-54e9-3719" name="Númenor" hidden="false" targetId="734e-e20e-e60f-72ec" primary="false"/>
+        <categoryLink id="8cf2-1980-205d-04f1" name="Unique Númenor" hidden="false" targetId="9857-d271-aaa7-38d6" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="f027-3a4e-bb13-307a" name="Isildur, Prince of Númenor" hidden="false" collective="false" import="true" targetId="db13-df84-5b76-8c93" type="selectionEntry"/>

--- a/The Serpent Horde.cat
+++ b/The Serpent Horde.cat
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="90ef-373f-f925-d8c8" name="The Serpent Horde" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="5f7d-b3a4-1743-38bd" name="Suladân&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="f7ad-346b-7d7b-bb50" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="f7b8-29cf-76a2-be77" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+        <categoryLink id="0c45-4a08-6e23-4fb2" name="Serpent Guard" hidden="false" targetId="1a7e-5429-722d-642c" primary="false"/>
+        <categoryLink id="22bb-81ed-3466-537e" name="Serpent Rider" hidden="false" targetId="c310-8640-6445-1bbc" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="9f01-bd35-08f5-28ad" name="Suladân, the Serpent Lord" hidden="false" collective="false" import="true" targetId="b9f0-a4f7-6d7e-d895" type="selectionEntry"/>
+        <entryLink id="7f7d-cf6d-dcf2-263b" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="69ad-ebeb-1345-c01b" name="Chieftain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="35b0-43fe-6522-79d7" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="c411-8d68-5a12-8c9f" name="Haradrim Chieftain" hidden="false" collective="false" import="true" targetId="7b92-0e7b-2637-a09d" type="selectionEntry"/>
+        <entryLink id="8f6e-2936-cbd5-6c13" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="5a07-f552-0a93-c136" name="Mûmak&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="a8f0-cb5c-6fc9-8d25" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="87d8-b34f-dd82-cc3f" name="War Mûmak of Harad" hidden="false" collective="false" import="true" targetId="5ed9-a83f-ad98-678f" type="selectionEntry"/>
+        <entryLink id="d530-2296-d136-1818" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="6ea3-7db5-2acd-34ba" name="Taskmaster&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="9434-1623-de79-a57d" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="f082-19e6-8970-c92b" name="Haradrim Taskmaster" hidden="false" collective="false" import="true" targetId="e2a8-1554-a481-dd59" type="selectionEntry"/>
+        <entryLink id="0059-dab9-30f3-dba8" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="1738-c926-d889-4b66" name="Râza&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="d813-1c7b-9739-01a6" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="9c1a-1fb3-08b3-85c9" name="Serpent Guard" hidden="false" targetId="1a7e-5429-722d-642c" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="0b89-3ac2-3be5-2514" name="Râza, Fang of the Serpent" hidden="false" collective="false" import="true" targetId="e969-153e-5e22-c64a" type="selectionEntry"/>
+        <entryLink id="37c0-b60a-a7b5-4687" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+  </selectionEntries>
+  <rules>
+    <rule id="9d23-f4b3-f813-750d" name="Suladân&apos;s Bodyguard" publicationId="8e2e-f1ed-1aa8-11ca" page="183" hidden="false">
+      <description>So long as Suladân has Will Points remaining, friendly Elite models gain the Sworn Protector (Suladân) special rule.</description>
+    </rule>
+    <rule id="c5a0-9a5b-2396-7357" name="The Scorpion&apos;s Sting" publicationId="8e2e-f1ed-1aa8-11ca" page="183" hidden="false">
+      <description>Friendly models with the Poisoned Attacks (bow) special rule exchange it for Poisonsed Attacks on all of their weapons.</description>
+    </rule>
+    <rule id="9785-7fb1-9784-bead" name="Lethal Toxins" publicationId="8e2e-f1ed-1aa8-11ca" page="183" hidden="false">
+      <description>Once per game, at the start of any Fight Phase, Suladân can use this special rule so long as he is alive and on the battlefield. If he does, then friendly Harad models gain the Bane of Kings special rule until the End Phase of the turn. This is treated as an Active ability belonging to Suladân.</description>
+    </rule>
+  </rules>
+  <infoLinks>
+    <infoLink id="6940-967a-25ea-ebab" name="Sworn Protector (X) [Passive]" hidden="false" targetId="e31a-6f96-9f22-d2d1" type="rule">
+      <modifiers>
+        <modifier type="set" field="name" value="Sworn Protector (Suladân) [Passive]"/>
+      </modifiers>
+    </infoLink>
+    <infoLink id="295e-4c12-d3d1-19e2" name="Bane of Kings [Active]" hidden="false" targetId="3b25-0a6b-d43e-f7e9" type="rule"/>
+  </infoLinks>
+</catalogue>

--- a/The Shire.cat
+++ b/The Shire.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="921a-2666-3e51-3310" name="The Shire" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="921a-2666-3e51-3310" name="The Shire" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="1535-f02c-0b0d-961e" name="Gandalf&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -108,6 +108,84 @@
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="0ca2-dc09-d8da-7377" name="Paladin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="5501-3a80-b6d2-acf9" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="9b28-0d51-0e81-3f45" name="Took" hidden="false" targetId="415f-985a-1d6f-5b36" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="50ab-6aa8-39ce-c3be" name="Paladin Took, Thain of the Shire" hidden="false" collective="false" import="true" targetId="2662-776a-2246-0d14" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="08bc-05b6-49f9-1ff2" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="3aff-1f26-411d-d8cf" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="84d1-4e0e-b2c1-d701" name="Will&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="8384-a77e-f15f-03a3" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+        <categoryLink id="cc31-cfe3-833e-fcb1" name="Shirriff" hidden="false" targetId="38de-7978-da99-08ae" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="dc77-e290-381a-d138" name="Will Witfoot, Mayor of Michel Delving" hidden="false" collective="false" import="true" targetId="1983-176f-b407-4d17" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="8718-93b1-5e0b-cacc" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="ab6b-a6aa-ca26-4465" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="305a-d924-de9a-3410" name="Cotton&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="b2ca-4102-7ecb-a5c8" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="18fb-e621-8e11-faef" name="Farmer Tolman Cotton" hidden="false" collective="false" import="true" targetId="c06f-5599-9ba7-1cf9" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="998b-1d8d-1534-2205" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="aae8-cf78-0b88-690c" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7b16-c163-dd02-4ef5" name="Lotho&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="a1b6-df03-5ead-e83b" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="0a9c-f624-7422-db23" name="Lotho Sackville-Baggins" hidden="false" collective="false" import="true" targetId="f981-ce3d-6134-5bc5" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e5f7-3808-3ce1-c6fb" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="762c-81f5-6c9c-e01e" name="Followers" hidden="false" collective="false" import="true" targetId="f88d-1ecb-eb54-b9eb" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </selectionEntries>
   <entryLinks>
     <entryLink id="a218-39f8-a2c7-a2d3" name="Meriadoc Brandybuck" hidden="false" collective="false" import="true" targetId="f4f2-ed76-cf8c-26d3" type="selectionEntry">
@@ -128,6 +206,16 @@
     <entryLink id="f57c-c729-3b37-c899" name="Lobelia Sackville-Baggins" hidden="false" collective="false" import="true" targetId="c6c3-3058-3e95-e8a7" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8f83-70e1-0424-687a" name="New CategoryLink" hidden="false" targetId="13f2-59a9-5a73-a03f" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="5c55-8880-5afa-daa6" name="Fredegar &apos;Fatty&apos; Bolger" hidden="false" collective="false" import="true" targetId="1d4e-bda2-959a-0a9f" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="56e8-2bc3-39d7-ab45" name="New CategoryLink" hidden="false" targetId="13f2-59a9-5a73-a03f" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="b06f-52c9-a3d4-3316" name="Folco Boffin" hidden="false" collective="false" import="true" targetId="241a-bcca-fb7b-04e2" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="0a8f-dadb-a2ed-7d6f" name="New CategoryLink" hidden="false" targetId="13f2-59a9-5a73-a03f" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>

--- a/The Three Trolls.cat
+++ b/The Three Trolls.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="72ef-c2aa-3abb-2f6f" name="The Three Trolls" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="72ef-c2aa-3abb-2f6f" name="The Three Trolls" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="dee1-1c8d-80b6-d4e3" name="Bert the Troll" hidden="false" collective="false" import="true" targetId="d63e-dc9f-1078-a55b" type="selectionEntry"/>
     <entryLink id="a1db-0074-0940-3292" name="Tom the Troll" hidden="false" collective="false" import="true" targetId="8f72-187c-679d-0a9e" type="selectionEntry"/>

--- a/Thorin's Company.cat
+++ b/Thorin's Company.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="28c1-3796-09c3-2567" name="Thorin&apos;s Company" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="28c1-3796-09c3-2567" name="Thorin&apos;s Company" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="38b3-05c5-441f-35a2" name="Thorin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -37,6 +37,7 @@
       </constraints>
       <categoryLinks>
         <categoryLink id="11be-3e0c-f97c-7339" name="Hero of Valour" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+        <categoryLink id="d6ac-76f0-63ce-14e0" name="Eagle" hidden="false" targetId="8781-645f-4b0c-639e" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="959f-7859-48b6-65fa" name="Gwaihir" hidden="false" collective="false" import="true" targetId="f2a4-f867-4270-6422" type="selectionEntry"/>
@@ -60,6 +61,12 @@
           </constraints>
         </entryLink>
       </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
     </selectionEntry>
   </selectionEntries>
   <rules>

--- a/Uglúk's Scouts.cat
+++ b/Uglúk's Scouts.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="013b-7330-66c7-6e43" name="Uglúk&apos;s Scouts" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="3" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="013b-7330-66c7-6e43" name="Uglúk&apos;s Scouts" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="91f9-8a36-6a8d-0db4" name="Uglúk&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -13,6 +13,12 @@
         <entryLink id="1ed7-3cc5-e403-3ae9" name="Uglúk, Uruk-hai Scout Captain" hidden="false" collective="false" import="true" targetId="6639-dc82-2442-33fc" type="selectionEntry"/>
         <entryLink id="52bb-121e-6941-02cc" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
       </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="7e95-08a3-222a-7356" name="Snaga&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -23,6 +29,12 @@
         <entryLink id="a52d-27f2-175a-a1ff" name="Snaga, Orc Captain" hidden="false" collective="false" import="true" targetId="5e2b-011c-b039-047e" type="selectionEntry"/>
         <entryLink id="4c5b-a9c5-9f44-4d0b" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
       </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="44c3-dad7-983b-9646" name="Scout Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -33,6 +45,12 @@
         <entryLink id="db0b-b196-7eaf-38f6" name="Uruk-hai Scout Captain" hidden="false" collective="false" import="true" targetId="57ce-308a-abe6-b341" type="selectionEntry"/>
         <entryLink id="98b3-0499-275b-02a8" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
       </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="4a6a-ec23-0f09-556d" name="Grishnákh&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -43,6 +61,12 @@
         <entryLink id="6de1-062f-94ca-85f5" name="Grishnákh, Orc Captain" hidden="false" collective="false" import="true" targetId="8879-08e4-022c-a523" type="selectionEntry"/>
         <entryLink id="6cc5-d204-a266-5482" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
       </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="97a2-7dc7-65a1-65ae" name="Orc Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <categoryLinks>
@@ -53,6 +77,28 @@
         <entryLink id="235c-8a84-fe49-ec14" name="Isengard Orc Captain" hidden="false" collective="false" import="true" targetId="f0cf-6669-2e6b-a37c" type="selectionEntry"/>
         <entryLink id="0121-f1ea-d45f-8a8e" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
       </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aac3-a7c6-14d3-517c" name="Shaman&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="531c-2ade-ba8a-5991" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+        <categoryLink id="b731-7cc5-d671-4a18" name="Orc" hidden="false" targetId="5fc7-dee0-a596-75aa" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="99e4-d915-c8fe-1254" name="Isengard Orc Shaman" hidden="false" collective="false" import="true" targetId="5307-68b6-c4e9-2b96" type="selectionEntry"/>
+        <entryLink id="43b1-d9f6-086a-ccb5" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name=" Bow" typeId="5c04-22f1-fd0b-9279" value="0.0"/>
+        <cost name=" Warrior" typeId="5141-e5a1-1d1f-e715" value="0.0"/>
+        <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
+        <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
+      </costs>
     </selectionEntry>
   </selectionEntries>
   <entryLinks>

--- a/Umbar.cat
+++ b/Umbar.cat
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="bc09-f0ce-3887-c97a" name="Umbar" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <selectionEntries>
+    <selectionEntry id="651f-7bd8-5ddb-2bbd" name="Dalamyr&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="3960-53e9-44ca-90f1" name="New CategoryLink" hidden="false" targetId="6483-b676-c7e7-0831" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="74c9-8c49-b04e-633b" name="Dalamyr, Fleetmaster of Umbar" hidden="false" collective="false" import="true" targetId="b506-599f-e86f-8c54" type="selectionEntry"/>
+        <entryLink id="2338-6fc2-ce08-2e42" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="a0c2-175c-28ba-3750" name="Delgamar&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="4fb7-36dd-ab9d-100d" name="New CategoryLink" hidden="false" targetId="f17d-8301-f19c-f80d" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="df5c-3d09-892d-10ce" name="Delgamar, Gatemaster of Umbar" hidden="false" collective="false" import="true" targetId="594f-13fb-9882-549b" type="selectionEntry"/>
+        <entryLink id="4a69-6620-531d-4756" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="ef70-88c4-fd41-3409" name="Chieftain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="b650-9531-3511-75bb" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="82a5-b208-dbbc-9561" name="Haradrim Chieftain" hidden="false" collective="false" import="true" targetId="7b92-0e7b-2637-a09d" type="selectionEntry"/>
+        <entryLink id="f197-31c0-c84f-d477" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="f52c-23ea-9a82-f77a" name="Hâsharin&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="9501-d2b5-db68-6b39" type="min"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="cc5f-6fa6-46af-598f" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="bc18-3736-77ee-51a1" name="Hâsharin" hidden="false" collective="false" import="true" targetId="a573-9adf-207b-b3a4" type="selectionEntry"/>
+        <entryLink id="92c2-773c-062a-e8a8" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="022e-00c7-b7cc-d945" name="Captain&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="48dc-1270-1b5d-9217" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="3fcb-9468-09ae-8ad8" name="Corsair Captain" hidden="false" collective="false" import="true" targetId="61a7-12dd-9618-bde4" type="selectionEntry"/>
+        <entryLink id="63f2-dc01-fecb-387e" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="c5d9-86ee-eb94-a263" name="Bo&apos;sun&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="4d55-838c-fd5f-6275" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="86f1-6c60-8127-509d" name="Corsair Bo&apos;sun" hidden="false" collective="false" import="true" targetId="d376-bd96-e155-91c0" type="selectionEntry"/>
+        <entryLink id="42c5-8f7d-f619-5e23" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="e51f-0964-64f6-1d6d" name="Marshal&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="1758-6425-87ea-04d1" name="New CategoryLink" hidden="false" targetId="ef35-8c21-6b9c-cbb8" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="ede0-f137-6e78-d4ff" name="Black Númenórean Marshall" hidden="false" collective="false" import="true" targetId="a8c9-27ec-622b-06cf" type="selectionEntry"/>
+        <entryLink id="ef37-3d69-5c3e-5cc7" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+  </selectionEntries>
+  <rules>
+    <rule id="c499-7444-7370-2edb" name="Shadows of Umbar" publicationId="8e2e-f1ed-1aa8-11ca" page="185" hidden="false">
+      <description>Friendly models gain the Stalk Unseen special rule.</description>
+    </rule>
+    <rule id="bcb6-4a96-a34b-acc2" name="Seize Command" publicationId="8e2e-f1ed-1aa8-11ca" page="185" hidden="false">
+      <description>If during the End Phase of any turn, your General has only a single Wound remaining and is within 3&quot; and Line of Sight of a friendly Hâsharin, you may choose to remove your General as a casualty. If you do, you may immediately choose another friendly Hero to be your new General (this must still be a Hero with the highest Heroic Tier remaining). The previous model loses the General keyword and no longer counts as a General for the purpose of special rules or Victory Points. If a Hâsharin is your General, they cannot use this special rule to kill themselves - a different Hâsharin would have to be within 3&quot; to use this special rule.</description>
+    </rule>
+    <rule id="ea7b-fab2-14d9-fcc8" name="Death to Gondor" publicationId="8e2e-f1ed-1aa8-11ca" page="185" hidden="false">
+      <description>Friendly models gain the Hatred (Gondor) special rule.</description>
+    </rule>
+  </rules>
+</catalogue>

--- a/Wolves of Isengard.cat
+++ b/Wolves of Isengard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5075-6976-f01e-622c" name="Wolves of Isengard" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="5075-6976-f01e-622c" name="Wolves of Isengard" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="e47d-b49e-f4a0-2088" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="1496-95f3-27d1-da3d" name="Sharku&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -33,6 +33,15 @@
         <cost name=" Points" typeId="39c8-4238-d8ca-bac5" value="0.0"/>
         <cost name="Throwing Weapons" typeId="59c3-8846-5912-9f3b" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="ad88-d478-0bb5-b7e1" name="Shaman&apos;s Warband" hidden="false" collective="false" import="true" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="2558-e8a9-6343-493d" name="New CategoryLink" hidden="false" targetId="69e9-a8ab-6276-49e0" primary="true"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink id="ce23-5160-e320-dbf9" name="Isengard Orc Shaman" hidden="false" collective="false" import="true" targetId="5307-68b6-c4e9-2b96" type="selectionEntry"/>
+        <entryLink id="629e-8689-4840-9422" name="Followers" hidden="false" collective="false" import="true" targetId="4b3d-aa13-9a19-0d55" type="selectionEntryGroup"/>
+      </entryLinks>
     </selectionEntry>
   </selectionEntries>
   <rules>


### PR DESCRIPTION
All profiles from the Armies of Middle-Earth book have been added (or updated from the Arnor & Angmar PDF). All army lists have been added.
Army lists have been updated to include AoME options. Some QoL updates for lists like the Last Alliance which required unique faction heroes, I added categories to more cleanly show this. Other QoL includes making siege engines cleaner with the same type of category. This also involved removing all heroic tiers off the hero entry and solely into the "Hero's Warband" entry which also had them. Added Bilbo Baggins, aged hobbit rules as they were missing. Fixed him appearing in Lindon.